### PR TITLE
Minor adjustments to Trellis tests

### DIFF
--- a/servers/trellis/Dockerfile
+++ b/servers/trellis/Dockerfile
@@ -1,4 +1,4 @@
-FROM trellisldp/trellis
+FROM trellisldp/trellis:develop
 
-ENV JAVA_OPTS="-Dtrellis.http.weak.etag=false -Dtrellis.http.memento.headerdates=false -Dtrellis.http.precondition.required=true"
+ENV JAVA_OPTS="-Dtrellis.http.weak.etag=false -Dtrellis.http.memento.headerdates=false -Dtrellis.http.precondition.required=true -Dtrellis.triplestore.ldp.type=true"
 


### PR DESCRIPTION
This pulls in the Docker image representing the tip of development for Trellis. It also enables the inclusion of the LDP interaction model in the body of RDF responses (which is optional under LDP).