### PR TITLE
Add detail to test sections

### DIFF
--- a/what-to-test.md
+++ b/what-to-test.md
@@ -1,11 +1,42 @@
-In general, we want to test the following things: 
+In general, we want to test the following things:
 
-# Storage servers
-Four big categories, basically:
-* LDP Basic Containers (see LDP test suite)
-* Web Access Control (including agent groups, trustedApps, and WAC-Allow headers)
-* "Solid specifics": Sparql-update, Sparql-GET, Globbing, CORS headers, ...
-* WebSockets-pubsub
+# Resource Servers
+
+## Linked Data Platform
+
+All `MUST` categories of the LDP test suite need to pass for:
+
+* LDP Basic Containers
+* LDP RDFSource
+* LDP NonRDFSource
+
+The following `SHOULD` and `MAY` categories of the LDP test suite need to pass for:
+
+* Support for `POST`
+* Support for `PATCH`
+* Support for `PUT`
+* Support for `DELETE`
+
+## Web Access Control
+
+* Enforcement of ACL resources
+* Presence of ACL link header
+* Presence of WAC-Allow header
+* Support for agent groups
+* Support for trustedApps
+
+## Solid requirements
+
+* SPARQL-Update to modify resources
+* SPARQL-GET to read resources
+* Globbing
+* CORS headers
+
+## WebSockets pubsub
+
+* Inclusion of `Updates-VIA` header
+* Support for `sub` requests
+* Support for `pub` responses
 
 # Identity providers
 * Webid-oidc


### PR DESCRIPTION
This adds some more detail to the list of things we want to test.

In the LDP section, I added support for NonRDFSource (RDFSource is really just a subset of BasicContainer, but it might be nice to list it explicitly). I can back that out if it's not really a requirement. I also explicitly listed support for `POST`, `PUT`, `PATCH` and `DELETE`, since those are technically optional per LDP.
