### PR TITLE
Basic CORS origin tests

### DIFF
--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -6,7 +6,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 <#test-list> a test:FixtureTable ;
-    test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> ) .
+    test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> <#public-cors-origin-unset> ) .
 
 
 <#public-writeread-unauthn-alt> a test:Test ;
@@ -54,4 +54,23 @@
 <#public-cors-origin-set-res> a http:ResponseMessage ;
                     http:status 200 ;
                     httph:access_control_allow_origin <https://app.example> ;
+                    httph:content_type "text/turtle" .
+
+<#public-cors-origin-unset> a test:Test ;
+                dc:description "Testing CORS header when Origin is supplied by client"@en ;
+                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+                dc:identifier "http_req_res_list_unauthenticated" ;
+                test:params [
+                    test:requests ( <#public-cors-origin-unset-req> ) ;
+                    test:responses ( <#public-cors-origin-unset-res> )
+                            ] .
+
+<#public-cors-origin-unset-req> a http:RequestMessage ;
+                    http:method "GET" ;
+                    http:requestURI </public/verypublic/foobar.ttl> .
+
+<#public-cors-origin-unset-res> a http:ResponseMessage ;
+                    http:status 200 ;
+                    httph:access_control_allow_origin "*" ;
                     httph:content_type "text/turtle" .

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -38,7 +38,7 @@
 
 <#public-cors-origin-set> a test:Test ;
                 dc:description "Testing CORS header when Origin is supplied by client"@en ;
-                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
                 test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
                 dc:identifier "http_req_res_list_unauthenticated" ;
                 test:params [
@@ -53,12 +53,12 @@
 
 <#public-cors-origin-set-res> a http:ResponseMessage ;
                     http:status 200 ;
-                    httph:access_control_allow_origin <https://app.example> ;
-                    httph:content_type "text/turtle" .
+                    httph:access_control_allow_origin <https://app.example> .
+                        
 
 <#public-cors-origin-unset> a test:Test ;
                 dc:description "Testing CORS header when Origin is supplied by client"@en ;
-                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
                 test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
                 dc:identifier "http_req_res_list_unauthenticated" ;
                 test:params [
@@ -72,5 +72,6 @@
 
 <#public-cors-origin-unset-res> a http:ResponseMessage ;
                     http:status 200 ;
-                    httph:access_control_allow_origin "*" ;
-                    httph:content_type "text/turtle" .
+                    httph:access_control_allow_origin "*" .
+                                
+

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -6,7 +6,7 @@
 
 
 <#test-list> a test:FixtureTable ;
-    test:fixtures <#public-writeread-unauthn-alt> .
+    test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> ) .
 
 
 <#public-writeread-unauthn-alt> a test:Test ;
@@ -36,3 +36,21 @@
     httph:content_type "text/turtle" .
             
 
+<#public-cors-origin-set> a test:Test ;
+    dc:description "Testing CORS header when Origin is supplied by client"@en ;
+    test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+    dc:identifier "http_req_res_list_unauthenticated" ;
+    test:params [
+        test:requests ( <#public-cors-origin-set-req> ) ;
+        test:responses ( <#public-cors-origin-set-res> )
+                ] .
+
+<#public-cors-origin-set-req> a http:RequestMessage ;
+                    http:method "GET" ;
+                    httph:origin <https://app.example> ;
+                    http:requestURI </public/verypublic/foobar.ttl> .
+
+<#public-cors-origin-set-res> a http:ResponseMessage ;
+                    http:status 200 ;
+                    httph:access_control_allow_origin <https://app.example> ;
+                    httph:content_type "text/turtle" .

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -3,7 +3,7 @@
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix httph:<http://www.w3.org/2007/ont/httph#> .
 @prefix http: <http://www.w3.org/2007/ont/http#> .
-
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 <#test-list> a test:FixtureTable ;
     test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> ) .
@@ -37,13 +37,14 @@
             
 
 <#public-cors-origin-set> a test:Test ;
-    dc:description "Testing CORS header when Origin is supplied by client"@en ;
-    test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
-    dc:identifier "http_req_res_list_unauthenticated" ;
-    test:params [
-        test:requests ( <#public-cors-origin-set-req> ) ;
-        test:responses ( <#public-cors-origin-set-res> )
-                ] .
+                dc:description "Testing CORS header when Origin is supplied by client"@en ;
+                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+                dc:identifier "http_req_res_list_unauthenticated" ;
+                test:params [
+                    test:requests ( <#public-cors-origin-set-req> ) ;
+                    test:responses ( <#public-cors-origin-set-res> )
+                            ] .
 
 <#public-cors-origin-set-req> a http:RequestMessage ;
                     http:method "GET" ;


### PR DESCRIPTION
This tests that if the `Origin` header is present, the server responds with Access-Control-Allow-Origin as defined. This is in partial fulfilment of #7 .