### PR TITLE
A test for OPTIONS

### DIFF
--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -6,7 +6,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 <#test-list> a test:FixtureTable ;
-    test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> ) .
+    test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> <#public-cors-origin-unset> ) .
 
 
 <#public-writeread-unauthn-alt> a test:Test ;
@@ -54,4 +54,23 @@
 <#public-cors-origin-set-res> a http:ResponseMessage ;
                     http:status 200 ;
                     httph:access_control_allow_origin <https://app.example> ;
+                    httph:content_type "text/turtle" .
+
+<#public-cors-origin-unset> a test:Test ;
+                dc:description "Testing CORS header when Origin is supplied by client"@en ;
+                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+                dc:identifier "http_req_res_list_unauthenticated" ;
+                test:params [
+                    test:requests ( <#public-cors-origin-unset-req> ) ;
+                    test:responses ( <#public-cors-origin-unset-res> )
+                            ] .
+
+<#public-cors-origin-unset-req> a http:RequestMessage ;
+                    http:method "GET" ;
+                    http:requestURI </public/verypublic/foobar.ttl> .
+
+<#public-cors-origin-unset-res> a http:ResponseMessage ;
+                    http:status 200 ;
+                    httph:access_control_allow_origin "*" ;
                     httph:content_type "text/turtle" .

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -38,7 +38,7 @@
 
 <#public-cors-origin-set> a test:Test ;
                 dc:description "Testing CORS header when Origin is supplied by client"@en ;
-                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
                 test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
                 dc:identifier "http_req_res_list_unauthenticated" ;
                 test:params [
@@ -53,12 +53,12 @@
 
 <#public-cors-origin-set-res> a http:ResponseMessage ;
                     http:status 200 ;
-                    httph:access_control_allow_origin <https://app.example> ;
-                    httph:content_type "text/turtle" .
+                    httph:access_control_allow_origin <https://app.example> .
+                        
 
 <#public-cors-origin-unset> a test:Test ;
                 dc:description "Testing CORS header when Origin is supplied by client"@en ;
-                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
                 test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
                 dc:identifier "http_req_res_list_unauthenticated" ;
                 test:params [
@@ -72,5 +72,6 @@
 
 <#public-cors-origin-unset-res> a http:ResponseMessage ;
                     http:status 200 ;
-                    httph:access_control_allow_origin "*" ;
-                    httph:content_type "text/turtle" .
+                    httph:access_control_allow_origin "*" .
+                                
+

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -6,7 +6,7 @@
 
 
 <#test-list> a test:FixtureTable ;
-    test:fixtures <#public-writeread-unauthn-alt> .
+    test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> ) .
 
 
 <#public-writeread-unauthn-alt> a test:Test ;
@@ -36,3 +36,21 @@
     httph:content_type "text/turtle" .
             
 
+<#public-cors-origin-set> a test:Test ;
+    dc:description "Testing CORS header when Origin is supplied by client"@en ;
+    test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+    dc:identifier "http_req_res_list_unauthenticated" ;
+    test:params [
+        test:requests ( <#public-cors-origin-set-req> ) ;
+        test:responses ( <#public-cors-origin-set-res> )
+                ] .
+
+<#public-cors-origin-set-req> a http:RequestMessage ;
+                    http:method "GET" ;
+                    httph:origin <https://app.example> ;
+                    http:requestURI </public/verypublic/foobar.ttl> .
+
+<#public-cors-origin-set-res> a http:ResponseMessage ;
+                    http:status 200 ;
+                    httph:access_control_allow_origin <https://app.example> ;
+                    httph:content_type "text/turtle" .

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -95,12 +95,12 @@
 
 <#public-options-res> a http:ResponseMessage ;
                     http:status 200 ; # TODO: For this, we need bag and possibly subset tests
-                    httph:accept_patch	"application/json, application/sparql-update" ;
-                    httph:accept_post	"text/turtle, application/ld+json" ;
+                    httph:accept_patch	"application/json", "application/sparql-update" ;
+                    httph:accept_post	"text/turtle", "application/ld+json" ;
                     httph:access_control_allow_credentials	"true" ;
-                    httph:access_control_allow_methods	"OPTIONS, HEAD, GET, PATCH, POST, PUT, DELETE" ;
+                    httph:access_control_allow_methods	"OPTIONS", "HEAD", "GET", "PATCH", "POST", "PUT", "DELETE" ;
                     httph:access_control_allow_origin	"*" ;
-                    httph:access_control_expose_headers	"User, Triples, Location, Link, Vary, Last-Modified, Content-Length" ;
-                    httph:allow	"OPTIONS, HEAD, GET, PATCH, POST, PUT, DELETE" .
+                    httph:access_control_expose_headers	"User", "Triples", "Location", "Link", "Vary", "Last-Modified", "Content-Length" ;
+                    httph:allow	"OPTIONS", "HEAD", "GET", "PATCH", "POST", "PUT", "DELETE" .
                                         
 

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -3,7 +3,7 @@
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix httph:<http://www.w3.org/2007/ont/httph#> .
 @prefix http: <http://www.w3.org/2007/ont/http#> .
-
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 <#test-list> a test:FixtureTable ;
     test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> ) .
@@ -37,13 +37,14 @@
             
 
 <#public-cors-origin-set> a test:Test ;
-    dc:description "Testing CORS header when Origin is supplied by client"@en ;
-    test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
-    dc:identifier "http_req_res_list_unauthenticated" ;
-    test:params [
-        test:requests ( <#public-cors-origin-set-req> ) ;
-        test:responses ( <#public-cors-origin-set-res> )
-                ] .
+                dc:description "Testing CORS header when Origin is supplied by client"@en ;
+                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+                test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+                dc:identifier "http_req_res_list_unauthenticated" ;
+                test:params [
+                    test:requests ( <#public-cors-origin-set-req> ) ;
+                    test:responses ( <#public-cors-origin-set-res> )
+                            ] .
 
 <#public-cors-origin-set-req> a http:RequestMessage ;
                     http:method "GET" ;

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -6,7 +6,12 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 
 <#test-list> a test:FixtureTable ;
-    test:fixtures ( <#public-writeread-unauthn-alt>  <#public-cors-origin-set> <#public-cors-origin-unset> ) .
+    test:fixtures (
+        <#public-writeread-unauthn-alt>
+        <#public-cors-origin-set>
+        <#public-cors-origin-unset>
+        <#public-options>
+        ) .
 
 
 <#public-writeread-unauthn-alt> a test:Test ;
@@ -73,5 +78,29 @@
 <#public-cors-origin-unset-res> a http:ResponseMessage ;
                     http:status 200 ;
                     httph:access_control_allow_origin "*" .
-                                
+
+<#public-options> a test:Test ;
+                dc:description "Testing OPTIONS method"@en ;
+                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/b941ff795acdedb7d7a24d40dabdfcce7efa9283/api-rest.md#discovering-server-capabilities---the-options-method>, <https://www.w3.org/TR/cors/#syntax> ;
+                test:handler "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+                dc:identifier "http_req_res_list_unauthenticated" ;
+                test:params [
+                    test:requests ( <#public-options-req> ) ;
+                    test:responses ( <#public-options-res> )
+                            ] .
+
+<#public-options-req> a http:RequestMessage ;
+                    http:method "OPTIONS" ;
+                    http:requestURI </public/> .
+
+<#public-options-res> a http:ResponseMessage ;
+                    http:status 200 ; # TODO: For this, we need bag and possibly subset tests
+                    httph:accept_patch	"application/json, application/sparql-update" ;
+                    httph:accept_post	"text/turtle, application/ld+json" ;
+                    httph:access_control_allow_credentials	"true" ;
+                    httph:access_control_allow_methods	"OPTIONS, HEAD, GET, PATCH, POST, PUT, DELETE" ;
+                    httph:access_control_allow_origin	"*" ;
+                    httph:access_control_expose_headers	"User, Triples, Location, Link, Vary, Last-Modified, Content-Length" ;
+                    httph:allow	"OPTIONS, HEAD, GET, PATCH, POST, PUT, DELETE" .
+                                        
 


### PR DESCRIPTION
Here's a test for some of the other CORS headers. It may be merged with it all or separately by changing the base. 

What's new here is that it has multiple field values, which adds some more requirements for the framework.