### PR TITLE
Authenticated tests

### DIFF
--- a/testers/rdf-fixtures/fixture-tables/acl-test.ttl
+++ b/testers/rdf-fixtures/fixture-tables/acl-test.ttl
@@ -19,12 +19,18 @@
 
 
 :get_basic_auth a test:AutomatedTest ;
-    test:purpose "A simple test for PUT then GET"@en ;
+    test:purpose "Bob checks root and puts illegally"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ; # Means: Bob wants to see Alice's data
-        test:requests ( :bob_simple_get_req ) ;
-        test:responses ( :bob_simple_get_res )
+        test:requests (
+            :bob_simple_get_req
+            :bob_simple_put_req
+        ) ;
+        test:responses (
+            :bob_simple_get_res
+            :bob_simple_put_res
+        )
     ] .
 
 :bob_simple_get_req a http:RequestMessage ;
@@ -34,4 +40,12 @@
 :bob_simple_get_res a http:ResponseMessage ;
     http:status 200 ;
     httph:content_type "text/html" .
+
+:bob_simple_put_req a http:RequestMessage ;
+    http:method "PUT" ;
+    http:content "</foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
+    http:requestURI </foobar.ttl> .
+
+:bob_simple_put_res a http:ResponseMessage ;
+    http:status 403 .
 

--- a/testers/rdf-fixtures/fixture-tables/acl-test.ttl
+++ b/testers/rdf-fixtures/fixture-tables/acl-test.ttl
@@ -12,6 +12,8 @@
         :bob_tries_get_put
         :alice_tries_get_put
         :alice_sets_bob_acl
+        :bob_tries_put_again
+        :teardown
     ) .
 
 <http://example.org/httplist#http_req_res_list>
@@ -40,7 +42,7 @@
     test:purpose "Alice checks root and puts fine"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
-        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ; # Means: Bob wants to see Alice's data
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:requests (
             :simple_get_req
             :simple_put_req
@@ -56,12 +58,43 @@
     test:purpose "Alice sets ACL for Bob"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
-        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ; # Means: Bob wants to see Alice's data
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:requests (
             :bob_put_acl_req
         ) ;
         test:responses (
             :bob_put_acl_res
+        )
+    ] .
+
+
+:bob_tries_put_again a test:AutomatedTest ;
+    test:purpose "Bob puts again and checks it is there"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:requests (
+            :simple_put_req
+            :simple_get_bob_req
+        ) ;
+        test:responses (
+            :bob_ok_put_res
+            :bob_simple_get_res
+        )
+    ] .
+
+:teardown a test:AutomatedTest ;
+    test:purpose "Teardown test to reset to initial state"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:requests (
+            :delete_bob_foobar_req
+            :delete_bob_req
+        ) ;
+        test:responses (
+            :delete_bob_res
+            :delete_bob_res
         )
     ] .
 
@@ -77,8 +110,8 @@
 :simple_put_req a http:RequestMessage ;
     http:method "PUT" ;
     httph:content_type "text/turtle" ;
-    http:content "</foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
-    http:requestURI </foobar.ttl> .
+    http:content "</bob/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
+    http:requestURI </bob/foobar.ttl> .
 
 :bob_simple_put_res a http:ResponseMessage ;
     http:status 403 .
@@ -92,9 +125,34 @@
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
     <#bob> a acl:Authorization;
-    acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+    acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>,
+              <https://alice.idp.test.solidproject.org/profile/card#me>;
     acl:default </bob/>;
+    acl:accessTo </bob/>;
     acl:mode acl:Read, acl:Write.""" .
 
 :bob_put_acl_res a http:ResponseMessage ;
     http:status 201 .
+
+:bob_ok_put_res a http:ResponseMessage ;
+    http:status 201 .
+
+:simple_get_bob_req a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </bob/foobar.ttl> .
+
+:bob_simple_get_res a http:ResponseMessage ;
+    http:status 200 ;
+    httph:content_type "text/turtle" .
+
+
+:delete_bob_foobar_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </bob/foobar.ttl> .
+
+:delete_bob_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </bob/> .
+
+:delete_bob_res a http:ResponseMessage ;
+    http:status 200 .

--- a/testers/rdf-fixtures/fixture-tables/acl-test.ttl
+++ b/testers/rdf-fixtures/fixture-tables/acl-test.ttl
@@ -11,6 +11,7 @@
     test:fixtures (
         :bob_tries_get_put
         :alice_tries_get_put
+        :alice_sets_bob_acl
     ) .
 
 <http://example.org/httplist#http_req_res_list>
@@ -51,6 +52,20 @@
     ] .
 
 
+:alice_sets_bob_acl a test:AutomatedTest ;
+    test:purpose "Alice sets ACL for Bob"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ; # Means: Bob wants to see Alice's data
+        test:requests (
+            :bob_put_acl_req
+        ) ;
+        test:responses (
+            :bob_put_acl_res
+        )
+    ] .
+
+
 :simple_get_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </> . # Will request index.html
@@ -61,6 +76,7 @@
 
 :simple_put_req a http:RequestMessage ;
     http:method "PUT" ;
+    httph:content_type "text/turtle" ;
     http:content "</foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
     http:requestURI </foobar.ttl> .
 
@@ -70,3 +86,15 @@
 :alice_simple_put_res a http:ResponseMessage ;
     http:status 201 .
 
+:bob_put_acl_req a http:RequestMessage ;
+    http:method "PUT" ;
+    http:requestURI </bob/.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+    <#bob> a acl:Authorization;
+    acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+    acl:default </bob/>;
+    acl:mode acl:Read, acl:Write.""" .
+
+:bob_put_acl_res a http:ResponseMessage ;
+    http:status 201 .

--- a/testers/rdf-fixtures/fixture-tables/acl-test.ttl
+++ b/testers/rdf-fixtures/fixture-tables/acl-test.ttl
@@ -9,7 +9,7 @@
 
 :test_list a test:FixtureTable ;
     test:fixtures (
-        :get_basic_auth
+        :bob_tries_get_put
     ) .
 
 <http://example.org/httplist#http_req_res_list>
@@ -18,7 +18,7 @@
     nfo:definesFunction "http_req_res_list" .
 
 
-:get_basic_auth a test:AutomatedTest ;
+:bob_tries_get_put a test:AutomatedTest ;
     test:purpose "Bob checks root and puts illegally"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [

--- a/testers/rdf-fixtures/fixture-tables/acl-test.ttl
+++ b/testers/rdf-fixtures/fixture-tables/acl-test.ttl
@@ -10,6 +10,7 @@
 :test_list a test:FixtureTable ;
     test:fixtures (
         :bob_tries_get_put
+        :alice_tries_get_put
     ) .
 
 <http://example.org/httplist#http_req_res_list>
@@ -24,28 +25,48 @@
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ; # Means: Bob wants to see Alice's data
         test:requests (
-            :bob_simple_get_req
-            :bob_simple_put_req
+            :simple_get_req
+            :simple_put_req
         ) ;
         test:responses (
-            :bob_simple_get_res
+            :simple_get_res
             :bob_simple_put_res
         )
     ] .
 
-:bob_simple_get_req a http:RequestMessage ;
+
+:alice_tries_get_put a test:AutomatedTest ;
+    test:purpose "Alice checks root and puts fine"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ; # Means: Bob wants to see Alice's data
+        test:requests (
+            :simple_get_req
+            :simple_put_req
+        ) ;
+        test:responses (
+            :simple_get_res
+            :alice_simple_put_res
+        )
+    ] .
+
+
+:simple_get_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </> . # Will request index.html
 
-:bob_simple_get_res a http:ResponseMessage ;
+:simple_get_res a http:ResponseMessage ;
     http:status 200 ;
     httph:content_type "text/html" .
 
-:bob_simple_put_req a http:RequestMessage ;
+:simple_put_req a http:RequestMessage ;
     http:method "PUT" ;
     http:content "</foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
     http:requestURI </foobar.ttl> .
 
 :bob_simple_put_res a http:ResponseMessage ;
     http:status 403 .
+
+:alice_simple_put_res a http:ResponseMessage ;
+    http:status 201 .
 

--- a/testers/rdf-fixtures/fixture-tables/acl-test.ttl
+++ b/testers/rdf-fixtures/fixture-tables/acl-test.ttl
@@ -1,0 +1,37 @@
+@prefix test: <http://ontologi.es/doap-tests#> .
+@prefix deps: <http://ontologi.es/doap-deps#>.
+@prefix httph:<http://www.w3.org/2007/ont/httph#> .
+@prefix http: <http://www.w3.org/2007/ont/http#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix my:   <http://example.org/my-parameters#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/acl-test.ttl#> .
+
+:test_list a test:FixtureTable ;
+    test:fixtures (
+        :get_basic_auth
+    ) .
+
+<http://example.org/httplist#http_req_res_list>
+    a nfo:SoftwareItem ;
+    deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+    nfo:definesFunction "http_req_res_list" .
+
+
+:get_basic_auth a test:AutomatedTest ;
+    test:purpose "A simple test for PUT then GET"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ; # Means: Bob wants to see Alice's data
+        test:requests ( :bob_simple_get_req ) ;
+        test:responses ( :bob_simple_get_res )
+    ] .
+
+:bob_simple_get_req a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </> . # Will request index.html
+
+:bob_simple_get_res a http:ResponseMessage ;
+    http:status 200 ;
+    httph:content_type "text/html" .
+

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -14,15 +14,15 @@
         :public_options
     ) .
 
-<http://example.org/httplist#http_req_res_list_unauthenticated>
+<http://example.org/httplist#http_req_res_list>
     a nfo:SoftwareItem ;
     deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
-    nfo:definesFunction "http_req_res_list_unauthenticated" .
+    nfo:definesFunction "http_req_res_list" .
 
 
 :public_writeread_unauthn_alt a test:AutomatedTest ;
     test:purpose "A simple test for PUT then GET"@en ;
-    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         test:requests ( :public_writeread_unauthn_alt_put_req :public_writeread_unauthn_alt_get_req ) ;
         test:responses ( :public_writeread_unauthn_alt_put_res :public_writeread_unauthn_alt_get_res )
@@ -49,7 +49,7 @@
 :public_cors_origin_set a test:AutomatedTest ;
     test:purpose "Testing CORS header when Origin is supplied by client"@en ;
     rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
-    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         test:requests ( :public_cors_origin_set_req ) ;
         test:responses ( :public_cors_origin_set_res )
@@ -68,7 +68,7 @@
 :public_cors_origin_unset a test:AutomatedTest ;
     test:purpose "Testing CORS header when Origin is not supplied by client"@en ;
     rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
-    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         test:requests ( :public_cors_origin_unset_req ) ;
         test:responses ( :public_cors_origin_unset_res )
@@ -85,7 +85,7 @@
 :public_options a test:AutomatedTest ;
     test:purpose "Testing OPTIONS method"@en ;
     rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/b941ff795acdedb7d7a24d40dabdfcce7efa9283/api-rest.md#discovering-server-capabilities---the-options-method>, <https://www.w3.org/TR/cors/#syntax> ;
-    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         test:requests ( :public_options_req ) ;
         test:responses ( :public_options_res )

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -11,7 +11,7 @@
         <#public-cors-origin-set>
         <#public-cors-origin-unset>
         <#public-options>
-        ) .
+    ) .
 
 <http://example.org/httplist#http_req_res_list_unauthenticated>
     a nfo:SoftwareItem ;
@@ -23,85 +23,85 @@
     test:purpose "A simple test for PUT then GET"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( <#public-writeread-unauthn-alt-put-req> <#public-writeread-unauthn-alt-get-req> ) ;
-        test:responses ( <#public-writeread-unauthn-alt-put-res> <#public-writeread-unauthn-alt-get-res> ) 
-                ] .
-                
+        test:requests ( <public-writeread-unauthn-alt-put-req> <public-writeread-unauthn-alt-get-req> ) ;
+        test:responses ( <public-writeread-unauthn-alt-put-res> <public-writeread-unauthn-alt-get-res> ) 
+    ] .
+
 
 <#public-writeread-unauthn-alt-put-req> a http:RequestMessage ;
-            http:method "PUT" ;
-            httph:content_type "text/turtle" ;
-            http:content "</public/verypublic/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
-            http:requestURI </public/verypublic/foobar.ttl> .
-          
+    http:method "PUT" ;
+    httph:content_type "text/turtle" ;
+    http:content "</public/verypublic/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
+    http:requestURI </public/verypublic/foobar.ttl> .
+
 <#public-writeread-unauthn-alt-put-res> a http:ResponseMessage ;
     http:status 201 .
 
 <#public-writeread-unauthn-alt-get-req> a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </public/verypublic/foobar.ttl> .
-            
+
 <#public-writeread-unauthn-alt-get-res> a http:ResponseMessage ;
     httph:content_type "text/turtle" .
-            
+
 
 <#public-cors-origin-set> a test:AutomatedTest ;
-                test:purpose "Testing CORS header when Origin is supplied by client"@en ;
-                rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
-                test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
-                test:params [
-                    test:requests ( <#public-cors-origin-set-req> ) ;
-                    test:responses ( <#public-cors-origin-set-res> )
-                            ] .
+    test:purpose "Testing CORS header when Origin is supplied by client"@en ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:params [
+        test:requests ( <#public-cors-origin-set-req> ) ;
+        test:responses ( <#public-cors-origin-set-res> )
+    ] .
 
 <#public-cors-origin-set-req> a http:RequestMessage ;
-                    http:method "GET" ;
-                    httph:origin <https://app.example> ;
-                    http:requestURI </public/verypublic/foobar.ttl> .
+    http:method "GET" ;
+    httph:origin <https://app.example> ;
+    http:requestURI </public/verypublic/foobar.ttl> .
 
 <#public-cors-origin-set-res> a http:ResponseMessage ;
-                    http:status 200 ;
-                    httph:access_control_allow_origin <https://app.example> .
-                        
+    http:status 200 ;
+    httph:access_control_allow_origin <https://app.example> .
+
 
 <#public-cors-origin-unset> a test:AutomatedTest ;
-                test:purpose "Testing CORS header when Origin is not supplied by client"@en ;
-                rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
-                test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
-                test:params [
-                    test:requests ( <#public-cors-origin-unset-req> ) ;
-                    test:responses ( <#public-cors-origin-unset-res> )
-                            ] .
+    test:purpose "Testing CORS header when Origin is not supplied by client"@en ;
+    rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
+    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:params [
+        test:requests ( <#public-cors-origin-unset-req> ) ;
+        test:responses ( <#public-cors-origin-unset-res> )
+    ] .
 
 <#public-cors-origin-unset-req> a http:RequestMessage ;
-                    http:method "GET" ;
-                    http:requestURI </public/verypublic/foobar.ttl> .
+    http:method "GET" ;
+    http:requestURI </public/verypublic/foobar.ttl> .
 
 <#public-cors-origin-unset-res> a http:ResponseMessage ;
-                    http:status 200 ;
-                    httph:access_control_allow_origin "*" .
+    http:status 200 ;
+    httph:access_control_allow_origin "*" .
 
 <#public-options> a test:AutomatedTest ;
-                test:purpose "Testing OPTIONS method"@en ;
-                rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/b941ff795acdedb7d7a24d40dabdfcce7efa9283/api-rest.md#discovering-server-capabilities---the-options-method>, <https://www.w3.org/TR/cors/#syntax> ;
-                test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
-                test:params [
-                    test:requests ( <#public-options-req> ) ;
-                    test:responses ( <#public-options-res> )
-                            ] .
+    test:purpose "Testing OPTIONS method"@en ;
+    rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/b941ff795acdedb7d7a24d40dabdfcce7efa9283/api-rest.md#discovering-server-capabilities---the-options-method>, <https://www.w3.org/TR/cors/#syntax> ;
+    test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
+    test:params [
+        test:requests ( <#public-options-req> ) ;
+        test:responses ( <#public-options-res> )
+    ] .
 
 <#public-options-req> a http:RequestMessage ;
-                    http:method "OPTIONS" ;
-                    http:requestURI </public/> .
+    http:method "OPTIONS" ;
+    http:requestURI </public/> .
 
 <#public-options-res> a http:ResponseMessage ;
-                    http:status 200 ; # TODO: For this, we need bag and possibly subset tests
-                    httph:accept_patch	"application/json", "application/sparql-update" ;
-                    httph:accept_post	"text/turtle", "application/ld+json" ;
-                    httph:access_control_allow_credentials	"true" ;
-                    httph:access_control_allow_methods	"OPTIONS", "HEAD", "GET", "PATCH", "POST", "PUT", "DELETE" ;
-                    httph:access_control_allow_origin	"*" ;
-                    httph:access_control_expose_headers	"User", "Triples", "Location", "Link", "Vary", "Last-Modified", "Content-Length" ;
-                    httph:allow	"OPTIONS", "HEAD", "GET", "PATCH", "POST", "PUT", "DELETE" .
-                                        
+    http:status 200 ; # TODO: For this, we need bag and possibly subset tests
+    httph:accept_patch	"application/json", "application/sparql-update" ;
+    httph:accept_post	"text/turtle", "application/ld+json" ;
+    httph:access_control_allow_credentials	"true" ;
+    httph:access_control_allow_methods	"OPTIONS", "HEAD", "GET", "PATCH", "POST", "PUT", "DELETE" ;
+    httph:access_control_allow_origin	"*" ;
+    httph:access_control_expose_headers	"User", "Triples", "Location", "Link", "Vary", "Last-Modified", "Content-Length" ;
+    httph:allow	"OPTIONS", "HEAD", "GET", "PATCH", "POST", "PUT", "DELETE" .
+
 

--- a/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
+++ b/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl
@@ -3,14 +3,15 @@
 @prefix httph:<http://www.w3.org/2007/ont/httph#> .
 @prefix http: <http://www.w3.org/2007/ont/http#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix nfo:   <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/assume-world-writable.ttl#> .
 
-<#test-list> a test:FixtureTable ;
+:test_list a test:FixtureTable ;
     test:fixtures (
-        <#public-writeread-unauthn-alt>
-        <#public-cors-origin-set>
-        <#public-cors-origin-unset>
-        <#public-options>
+        :public_writeread_unauthn_alt
+        :public_cors_origin_set
+        :public_cors_origin_unset
+        :public_options
     ) .
 
 <http://example.org/httplist#http_req_res_list_unauthenticated>
@@ -19,82 +20,82 @@
     nfo:definesFunction "http_req_res_list_unauthenticated" .
 
 
-<#public-writeread-unauthn-alt> a test:AutomatedTest ;
+:public_writeread_unauthn_alt a test:AutomatedTest ;
     test:purpose "A simple test for PUT then GET"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( <public-writeread-unauthn-alt-put-req> <public-writeread-unauthn-alt-get-req> ) ;
-        test:responses ( <public-writeread-unauthn-alt-put-res> <public-writeread-unauthn-alt-get-res> ) 
+        test:requests ( :public_writeread_unauthn_alt_put_req :public_writeread_unauthn_alt_get_req ) ;
+        test:responses ( :public_writeread_unauthn_alt_put_res :public_writeread_unauthn_alt_get_res )
     ] .
 
 
-<#public-writeread-unauthn-alt-put-req> a http:RequestMessage ;
+:public_writeread_unauthn_alt_put_req a http:RequestMessage ;
     http:method "PUT" ;
     httph:content_type "text/turtle" ;
     http:content "</public/verypublic/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
     http:requestURI </public/verypublic/foobar.ttl> .
 
-<#public-writeread-unauthn-alt-put-res> a http:ResponseMessage ;
+:public_writeread_unauthn_alt_put_res a http:ResponseMessage ;
     http:status 201 .
 
-<#public-writeread-unauthn-alt-get-req> a http:RequestMessage ;
+:public_writeread_unauthn_alt_get_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </public/verypublic/foobar.ttl> .
 
-<#public-writeread-unauthn-alt-get-res> a http:ResponseMessage ;
+:public_writeread_unauthn_alt_get_res a http:ResponseMessage ;
     httph:content_type "text/turtle" .
 
 
-<#public-cors-origin-set> a test:AutomatedTest ;
+:public_cors_origin_set a test:AutomatedTest ;
     test:purpose "Testing CORS header when Origin is supplied by client"@en ;
     rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( <#public-cors-origin-set-req> ) ;
-        test:responses ( <#public-cors-origin-set-res> )
+        test:requests ( :public_cors_origin_set_req ) ;
+        test:responses ( :public_cors_origin_set_res )
     ] .
 
-<#public-cors-origin-set-req> a http:RequestMessage ;
+:public_cors_origin_set_req a http:RequestMessage ;
     http:method "GET" ;
     httph:origin <https://app.example> ;
     http:requestURI </public/verypublic/foobar.ttl> .
 
-<#public-cors-origin-set-res> a http:ResponseMessage ;
+:public_cors_origin_set_res a http:ResponseMessage ;
     http:status 200 ;
     httph:access_control_allow_origin <https://app.example> .
 
 
-<#public-cors-origin-unset> a test:AutomatedTest ;
+:public_cors_origin_unset a test:AutomatedTest ;
     test:purpose "Testing CORS header when Origin is not supplied by client"@en ;
     rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( <#public-cors-origin-unset-req> ) ;
-        test:responses ( <#public-cors-origin-unset-res> )
+        test:requests ( :public_cors_origin_unset_req ) ;
+        test:responses ( :public_cors_origin_unset_res )
     ] .
 
-<#public-cors-origin-unset-req> a http:RequestMessage ;
+:public_cors_origin_unset_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </public/verypublic/foobar.ttl> .
 
-<#public-cors-origin-unset-res> a http:ResponseMessage ;
+:public_cors_origin_unset_res a http:ResponseMessage ;
     http:status 200 ;
     httph:access_control_allow_origin "*" .
 
-<#public-options> a test:AutomatedTest ;
+:public_options a test:AutomatedTest ;
     test:purpose "Testing OPTIONS method"@en ;
     rdfs:isDefinedBy <https://github.com/solid/solid-spec/blob/b941ff795acdedb7d7a24d40dabdfcce7efa9283/api-rest.md#discovering-server-capabilities---the-options-method>, <https://www.w3.org/TR/cors/#syntax> ;
     test:test_script <http://example.org/httplist#http_req_res_list_unauthenticated> ;
     test:params [
-        test:requests ( <#public-options-req> ) ;
-        test:responses ( <#public-options-res> )
+        test:requests ( :public_options_req ) ;
+        test:responses ( :public_options_res )
     ] .
 
-<#public-options-req> a http:RequestMessage ;
+:public_options_req a http:RequestMessage ;
     http:method "OPTIONS" ;
     http:requestURI </public/> .
 
-<#public-options-res> a http:ResponseMessage ;
+:public_options_res a http:ResponseMessage ;
     http:status 200 ; # TODO: For this, we need bag and possibly subset tests
     httph:accept_patch	"application/json", "application/sparql-update" ;
     httph:accept_post	"text/turtle", "application/ld+json" ;

--- a/testers/rdf-fixtures/fixture-tables/basic.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic.ttl
@@ -4,9 +4,10 @@
 @prefix httph:<http://www.w3.org/2007/ont/httph#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/basic.ttl#> .
 
-<#test-list> a test:FixtureTable ;
-    test:fixtures <#public-read-unauthn>, <#write-with-bearer>, <#put-with-bearer> .
+:test_list a test:FixtureTable ;
+    test:fixtures :public_read_unauthn, :write_with_bearer, :put_with_bearer .
 
 <http://example.org/basic#http_methods_with_bearer> a nfo:SoftwareItem ;
     nfo:definesFunction "http_methods_with_bearer" ;
@@ -21,20 +22,20 @@
     deps:test-requirement "Web::Solid::Test::Basic"^^deps:CpanId .
 
 
-<#public-read-unauthn> a test:AutomatedTest ;
+:public_read_unauthn a test:AutomatedTest ;
     test:purpose "Test that GET and HEAD has the same headers" ;
     test:param_base <http://example.org/my-parameters#> ;
     test:test_script <http://example.org/basic#http_read_unauthenticated> ;
     test:params [ my:url </public/> ] .
 
 
-<#write-with-bearer> a test:AutomatedTest ;
+:write_with_bearer a test:AutomatedTest ;
     test:purpose "Test that a PUT can be done when using a environment Bearer Token" ;
     test:param_base <http://example.org/my-parameters#> ;
     test:test_script <http://example.org/basic#http_write_with_bearer> ;
     test:params [ my:url </private/foo.ttl> ] .
 
-<#put-with-bearer> a test:AutomatedTest ;
+:put_with_bearer a test:AutomatedTest ;
     test:purpose "Test that a PUT can be done when using a environment Bearer Token returning 201" ;
     test:param_base <http://example.org/my-parameters#> ;
     test:test_script <http://example.org/basic#http_methods_with_bearer> ;
@@ -42,5 +43,5 @@
         my:url </private/foo.ttl> ;
         my:method "PUT" ;
         my:body "" ;
-        my:code "201" 
+        my:code "201"
     ] .

--- a/testers/rdf-fixtures/fixture-tables/basic.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic.ttl
@@ -6,7 +6,7 @@
 @prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 
 <#test-list> a test:FixtureTable ;
-    test:fixtures <#public-read-unauthn>, <#write-with-bearer>, <#put-with-bearer> . 
+    test:fixtures <#public-read-unauthn>, <#write-with-bearer>, <#put-with-bearer> .
 
 <http://example.org/basic#http_methods_with_bearer> a nfo:SoftwareItem ;
     nfo:definesFunction "http_methods_with_bearer" ;
@@ -43,4 +43,4 @@
         my:method "PUT" ;
         my:body "" ;
         my:code "201" 
-        ] .
+    ] .

--- a/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
+++ b/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
@@ -9,6 +9,7 @@
 
 :test_list a test:FixtureTable ;
     test:fixtures (
+        :create_test_container
         :check_acl_location
     ) .
 
@@ -16,11 +17,41 @@
     deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
     nfo:definesFunction "http_req_res_list_location" .
 
+<http://example.org/httplist#http_req_res_list> a nfo:SoftwareItem ;
+    deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+    nfo:definesFunction "http_req_res_list" .
+
+
+:create_test_container a test:AutomatedTest ;
+    test:purpose "Create test container."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:requests ( :post_container_req ) ;
+        test:responses ( :post_container_res )
+    ] .
+
+:post_container_req  a http:RequestMessage ;
+    http:method "POST" ;
+    http:requestURI </> ;
+    httph:content_type "text/turtle";
+    httph:link '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"' ;
+    httph:slug "test" ;
+    http:content """@prefix ldp: <http://www.w3.org/ns/ldp#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+<> a ldp:Container, ldp:BasicContainer;
+   dcterms:title "Test Directory" .""".
+
+
+:post_container_res a http:ResponseMessage ;
+    http:status 201 .
+
 
 :check_acl_location a test:AutomatedTest ;
     test:purpose "Determine location and write ACL document"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list_location> ;
     test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:requests ( :check_acl_location_req :put_new_acl_req ) ;
         test:responses ( :check_acl_location_res :put_new_acl_res )
     ] .
@@ -28,11 +59,11 @@
 
 :check_acl_location_req a http:RequestMessage ;
     http:method "HEAD" ;
-    http:requestURI </> .
+    http:requestURI </test/> .
 
 :check_acl_location_res a http:ResponseMessage ;
     httph:link '<(.*?)>;\\s+rel="acl"'^^dqm:regex ;
-    httph:content_type "text/turtle" ;
+    #    httph:content_type "text/turtle" ;
     http:status 200 .
 
 :put_new_acl_req a http:RequestMessage ;

--- a/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
+++ b/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
@@ -83,4 +83,18 @@ acl:mode acl:Read. """ .
     http:status "201" .
 
 
+:teardown a test:AutomatedTest ;
+    test:purpose "Teardown test to reset to initial state"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:requests ( :delete_container_req ) ;
+        test:responses ( :delete_container_res )
+    ] .
 
+:delete_container_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </test/> .
+
+:delete_container_res a http:ResponseMessage ;
+    http:status 200 .

--- a/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
+++ b/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
@@ -1,0 +1,54 @@
+@prefix test: <http://ontologi.es/doap-tests#> .
+@prefix deps: <http://ontologi.es/doap-deps#>.
+@prefix httph:<http://www.w3.org/2007/ont/httph#> .
+@prefix http: <http://www.w3.org/2007/ont/http#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix dqm:  <http://purl.org/dqm-vocabulary/v1/dqm#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl#> .
+
+:test_list a test:FixtureTable ;
+    test:fixtures (
+        :check_acl_location
+    ) .
+
+<http://example.org/httplist#http_req_res_list_location> a nfo:SoftwareItem ;
+    deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+    nfo:definesFunction "http_req_res_list_location" .
+
+
+:check_acl_location a test:AutomatedTest ;
+    test:purpose "Determine location and write ACL document"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list_location> ;
+    test:params [
+        test:requests ( :check_acl_location_req :put_new_acl_req ) ;
+        test:responses ( :check_acl_location_res :put_new_acl_res )
+    ] .
+
+
+:check_acl_location_req a http:RequestMessage ;
+    http:method "HEAD" ;
+    http:requestURI </> .
+
+:check_acl_location_res a http:ResponseMessage ;
+    httph:link '<(.*?)>;\\s+rel="acl"'^^dqm:regex ;
+    httph:content_type "text/turtle" ;
+    http:status 200 .
+
+:put_new_acl_req a http:RequestMessage ;
+    http:method "PUT" ;
+    httph:content_type "text/turtle" ;
+http:content """
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+acl:default </>;
+acl:accessTo </>;
+acl:agent <profile/card#me>;
+acl:mode acl:Read. """ .
+
+
+:put_new_acl_res a http:ResponseMessage ;
+    http:status "201" .
+
+
+

--- a/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
+++ b/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
@@ -11,6 +11,7 @@
     test:fixtures (
         :create_test_container
         :check_acl_location
+        :teardown
     ) .
 
 <http://example.org/httplist#http_req_res_list_location> a nfo:SoftwareItem ;
@@ -72,8 +73,8 @@
 http:content """
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
-acl:default </>;
-acl:accessTo </>;
+acl:default </test/>;
+acl:accessTo </test/>;
 acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
 acl:mode acl:Read. """ .
 

--- a/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
+++ b/testers/rdf-fixtures/fixture-tables/http-put-check-acl.ttl
@@ -74,7 +74,7 @@ http:content """
 <#owner> a acl:Authorization;
 acl:default </>;
 acl:accessTo </>;
-acl:agent <profile/card#me>;
+acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
 acl:mode acl:Read. """ .
 
 

--- a/testers/rdf-fixtures/run-scripts/acl-test-basic.t
+++ b/testers/rdf-fixtures/run-scripts/acl-test-basic.t
@@ -1,0 +1,54 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Testing HTTP interface functionality of a Solid server
+
+=head1 ENVIRONMENT
+
+=head2 C<SOLID_FIXTURE_PATH>
+
+Set the path to where the Turtle files with fixture tables are. Defaults to C</opt/fixture-tables/>.
+
+=head2 C<SOLID_REMOTE_BASE>
+
+B<Required> Sets the base URL to resolve URLs in the Turtle fixture tables against.
+
+=head1 AUTHOR
+
+Kjetil Kjernsmo E<lt>kjetilk@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is Copyright (c) 2019 by Inrupt Inc.
+
+This is free software, licensed under:
+
+  The MIT (X11) License
+
+
+=cut
+
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::FITesque;
+use Test::FITesque::Test;
+
+my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
+
+use Test::FITesque::RDF;
+
+BAIL_OUT("Set SOLID_REMOTE_BASE to the URL of the base of the server you are testing") unless $ENV{SOLID_REMOTE_BASE};
+
+my $suite = Test::FITesque::RDF->new(source => $path . 'http-put-check-acl.ttl', base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
+
+$suite->run_tests;
+
+done_testing;
+  
+

--- a/testers/rdf-fixtures/run-scripts/httplists.t
+++ b/testers/rdf-fixtures/run-scripts/httplists.t
@@ -45,7 +45,7 @@ use Test::FITesque::RDF;
 
 BAIL_OUT("Set SOLID_REMOTE_BASE to the URL of the base of the server you are testing") unless $ENV{SOLID_REMOTE_BASE};
 
-my $suite = Test::FITesque::RDF->new(source => $path . 'assume-world-writable.ttl', base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
+my $suite = Test::FITesque::RDF->new(source => $path . 'acl-test.ttl', base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
 
 $suite->run_tests;
 

--- a/testers/rdf-fixtures/start-acl.ttl
+++ b/testers/rdf-fixtures/start-acl.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#root_test_alice_auth> a acl:Authorization;
+    acl:default </>;
+    acl:accessTo </>;
+    acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+    acl:mode acl:Read, acl:Write, acl:Control.


### PR DESCRIPTION
With recent releases of the [framework](https://github.com/kjetilk/p5-test-fitesque-rdf) and the [test script module](https://github.com/kjetilk/p5-web-solid-test-basic), I have made some tests that use authorization to do some operations while interacting with two users. Afterwards, a teardown test removes the resources that the tests set up, so if the test suite doesn't crash, the tests can be run again.

These tests are the first real useful tests, and should serve as a basis for test development. I expect to retire some of the older stuff now. Please have a look at it.