### PR TITLE
Use the other test-idp tokens

### DIFF
--- a/testers/rdf-fixtures/fixture-tables/authentication.ttl
+++ b/testers/rdf-fixtures/fixture-tables/authentication.ttl
@@ -22,6 +22,13 @@
         :get_auth_bob_own_origin
         :get_auth_bob_alice_trust_origin
         :get_auth_bob_other_origin
+        :get_auth_bob_alice_trust_origin
+        :get_auth_bob_other_origin
+        :get_auth_alice_good_pop
+        :get_auth_alice_good_pop_trusted_origin
+        :get_auth_alice_bad_pop_trusted_origin
+        :get_auth_bob_good_pop_alice_trust_origin
+        :get_auth_bob_bad_pop_alice_trust_origin
         :teardown
     ) .
 
@@ -237,6 +244,71 @@
         )
     ] .
 
+
+:get_auth_alice_good_pop a test:AutomatedTest ;
+    test:purpose "Authenticated as Alice with good PoP token and GET operation on resource should return."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_POP_FOR_GOOD_APP_GOOD> ;
+        test:steps (
+            [
+                test:request :get_private_for_alice_req ;
+                test:response_assertion :get_ok_res
+            ]
+        )
+    ] .
+
+:get_auth_alice_good_pop_trusted_origin a test:AutomatedTest ;
+    test:purpose "Authenticated as Alice with good PoP token and GET operation on resource with system trusted origin should return."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_POP_FOR_GOOD_APP_GOOD> ;
+        test:steps (
+            [
+                test:request :get_alice_trust_origin_private_for_alice_req ;
+                test:response_assertion :get_ok_res
+            ]
+        )
+    ] .
+
+:get_auth_alice_bad_pop_trusted_origin a test:AutomatedTest ;
+    test:purpose "Authenticated as Alice with bad PoP token and GET operation on resource with system trusted origin should fail."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_POP_FOR_BAD_APP_GOOD> ;
+        test:steps (
+            [
+                test:request :get_alice_trust_origin_private_for_alice_req ;
+                test:response_assertion :user_unauthz_res # TODO: Is it Origin or User who fails? Should it be an invalid request?
+            ]
+        )
+    ] .
+
+:get_auth_bob_good_pop_alice_trust_origin a test:AutomatedTest ;
+    test:purpose "Authenticated as Bob with good PoP token and GET operation on resource belonging to Alice, with Alice's trusted origin."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_POP_FOR_GOOD_APP_GOOD> ;
+        test:steps (
+            [
+                test:request :get_alice_trust_origin_private_for_alice_req ;
+                test:response_assertion :user_unauthz_res
+            ]
+        )
+    ] .
+
+:get_auth_bob_bad_pop_alice_trust_origin a test:AutomatedTest ;
+    test:purpose "Authenticated as Bob with bad PoP token and GET operation on resource belonging to Alice, with Alice's trusted origin."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_POP_FOR_BAD_APP_GOOD> ;
+        test:steps (
+            [
+                test:request :get_alice_trust_origin_private_for_alice_req ;
+                test:response_assertion :user_unauthz_res
+            ]
+        )
+    ] .
 
 :get_private_for_alice_req a http:RequestMessage ;
     http:method "GET" ;

--- a/testers/rdf-fixtures/fixture-tables/authentication.ttl
+++ b/testers/rdf-fixtures/fixture-tables/authentication.ttl
@@ -134,7 +134,7 @@
     ] .
 
 :get_auth_alice a test:AutomatedTest ;
-    test:purpose "Authenticated as Alice GET operation on resource should fail."@en ;
+    test:purpose "Authenticated as Alice GET operation on resource should return."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
@@ -147,7 +147,7 @@
     ] .
 
 :get_auth_alice_own_origin a test:AutomatedTest ;
-    test:purpose "Authenticated as Alice GET operation on resource with Alice's own origin should fail.."@en ;
+    test:purpose "Authenticated as Alice GET operation on resource with Alice's own origin should return."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
@@ -160,7 +160,7 @@
     ] .
 
 :get_auth_alice_trusted_origin a test:AutomatedTest ;
-    test:purpose "Authenticated as Alice GET operation on resource with system trusted origin should fail."@en ;
+    test:purpose "Authenticated as Alice GET operation on resource with system trusted origin should return."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
@@ -173,7 +173,7 @@
     ] .
 
 :get_auth_alice_other_origin a test:AutomatedTest ;
-    test:purpose "Authenticated as Alice GET operation on resource with some other origin should fail.."@en ;
+    test:purpose "Authenticated as Alice GET operation on resource with some other origin should fail."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;


### PR DESCRIPTION
This PR adds tests using the other [test-idp tokens](https://github.com/solid/test-idp/blob/fc4a41a9663b7f6eb0914e9ebbb48c9a5c24f0d6/README.md#getting-tokens).

Of the 6 tests added below, 4 fail with current NSS `master`. They all return a `401`, and my intuition is that two of them should return a `200` and two `403`. But my intuition isn't strong with this one, I probably don't understand what the different tokens represent, so please advice. 

The first test uses `ALICE_POP_FOR_GOOD_APP_GOOD` to `GET` a resource that is private to Alice, but has no origin. Then, my intuition says that whether or not there is a PoP shouldn't matter, if Alice is authenticated, then it is the browsers lack of origin that should make it OK. Flawed reasoning?

The second uses `ALICE_POP_FOR_GOOD_APP_GOOD` to `GET` a resource that is private to Alice, and uses `https://goodapp.example`, which is given in Alice's profile as trusted. So, I'm guessing it should be OK, but perhaps there's a different app origin in the token, or something?

The third does the same, but with `ALICE_POP_FOR_BAD_APP_GOOD`. Then, I'm thinking that Alice is authenticated even though the token is for a bad app, and therefore, it shouldn't be `401`, but perhaps I don't understand what the bad PoP means, and I'm also open to other interpretations as to what it should be. I guess it could be argued the request is invalid when that happens.

The fourth test that fails does the same, but with `BOB_POP_FOR_GOOD_APP_GOOD`. Then, again, I'm thinking that Bob is authenticated, so `401` wouldn't be correct, but same disclaimer applies. 