### PR TITLE
WiP: ACL-restricted operations

### DIFF
--- a/testers/rdf-fixtures/fixture-tables/authentication.ttl
+++ b/testers/rdf-fixtures/fixture-tables/authentication.ttl
@@ -35,7 +35,7 @@
     test:purpose "Set up resources as needed by the rest of the tests"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
-        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ; # Means: Bob wants to see Alice's data
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
                 test:request :setup_alices_private_req ;
@@ -55,7 +55,6 @@
 :setup_alices_private_req a http:RequestMessage ;
     http:method "PUT" ;
     http:requestURI </test-auth/private-for-alice.txt> ;
-    rdfs:comment "Is this expected behaviour, i.e. putting a resource will create an empty container?"@en ;
     httph:content_type "text/plain" ;
     http:content "protected contents for alice" .
 

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -71,35 +71,35 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_r_nr_read_req ;
+                test:request :test_bob_nr_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_r_nr_head_req ;
+                test:request :test_bob_nr_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_r_nr_options_req ;
+                test:request :test_bob_nr_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_r_nr_write_req ;
+                test:request :test_bob_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_patch_req ;
+                test:request :test_bob_nr_patch_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_append_req ;
+                test:request :test_bob_nr_append_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_delete_req ;
+                test:request :test_bob_nr_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_other_req ;
+                test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -144,35 +144,35 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_r_nr_read_req ;
+                test:request :test_bob_nr_read_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_head_req ;
+                test:request :test_bob_nr_head_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_options_req ;
+                test:request :test_bob_nr_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_r_nr_write_req ;
+                test:request :test_bob_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_patch_req ;
+                test:request :test_bob_nr_patch_req ;
                 test:response_assertion :unsupported_media_type_res ;
             ]
             [
-                test:request :test_bob_r_nr_append_req ;
+                test:request :test_bob_nr_append_req ;
                 test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
             ]
             [
-                test:request :test_bob_r_nr_delete_req ;
+                test:request :test_bob_nr_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_other_req ;
+                test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -217,76 +217,76 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_r_nr_read_req ;
+                test:request :test_bob_nr_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_r_nr_head_req ;
+                test:request :test_bob_nr_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_r_nr_options_req ;
+                test:request :test_bob_nr_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_r_nr_write_req ;
+                test:request :test_bob_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_patch_req ;
+                test:request :test_bob_nr_patch_req ;
                 test:response_assertion :unsupported_media_type_res ;
             ]
             [
-                test:request :test_bob_r_nr_append_req ;
+                test:request :test_bob_nr_append_req ;
                 test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
             ]
             [
-                test:request :test_bob_r_nr_delete_req ;
+                test:request :test_bob_nr_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_other_req ;
+                test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
     ] .
 
 
-:test_bob_r_nr_read_req a http:RequestMessage ;
+:test_bob_nr_read_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:test_bob_r_nr_head_req a http:RequestMessage ;
+:test_bob_nr_head_req a http:RequestMessage ;
     http:method "HEAD" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:test_bob_r_nr_options_req a http:RequestMessage ;
+:test_bob_nr_options_req a http:RequestMessage ;
     http:method "OPTIONS" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:test_bob_r_nr_write_req a http:RequestMessage ;
+:test_bob_nr_write_req a http:RequestMessage ;
     http:method "PUT" ;
     http:content "Bob's replacement"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:test_bob_r_nr_patch_req a http:RequestMessage ;
+:test_bob_nr_patch_req a http:RequestMessage ;
     http:method "PATCH" ;
     http:content "+Bob's patch"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:test_bob_r_nr_append_req a http:RequestMessage ;
+:test_bob_nr_append_req a http:RequestMessage ;
     http:method "POST" ;
     http:content "Bob's addition"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:test_bob_r_nr_delete_req a http:RequestMessage ;
+:test_bob_nr_delete_req a http:RequestMessage ;
     http:method "DELETE" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:test_bob_r_nr_other_req a http:RequestMessage ;
+:test_bob_nr_other_req a http:RequestMessage ;
     http:method "DAHU" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
@@ -320,11 +320,11 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :teardown_alice_share_bob_r_req ;
+                test:request :teardown_alice_share_bob_req ;
                 test:response_assertion :deleted_ok_res
             ]
             [
-                test:request :teardown_alice_share_bob_r_acl_req ;
+                test:request :teardown_alice_share_bob_acl_req ;
                 test:response_assertion :deleted_ok_res
             ]
             [
@@ -335,11 +335,11 @@
         )
     ] .
 
-:teardown_alice_share_bob_r_req a http:RequestMessage ;
+:teardown_alice_share_bob_req a http:RequestMessage ;
     http:method "DELETE" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
 
-:teardown_alice_share_bob_r_acl_req a http:RequestMessage ;
+:teardown_alice_share_bob_acl_req a http:RequestMessage ;
     rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
     http:method "DELETE" ;
     http:requestURI </test-auth/alice_share_bob.txt.acl> .

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -13,6 +13,8 @@
         :test_bob_r_nr
         :setup_append
         :test_bob_a_nr
+        :setup_read_append
+        :test_bob_ar_nr
         :teardown
     ) .
 
@@ -119,7 +121,7 @@
     ] .
 
 :setup_alice_share_bob_a_nr_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read.";
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to append.";
     http:method "PUT" ;
     http:requestURI </test-auth/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
@@ -148,6 +150,79 @@
             [
                 test:request :test_bob_r_nr_head_req ;
                 test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_write_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_patch_req ;
+                test:response_assertion :unsupported_media_type_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_delete_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_other_req ;
+                test:response_assertion :invalid_req_res ;
+            ]
+        )
+    ] .
+
+
+
+:setup_read_append a test:AutomatedTest ;
+    test:purpose "Modify ACL to add append and read to resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_ar_nr_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_ar_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and append.";
+    http:method "PUT" ;
+    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:mode acl:Read, acl:Append.
+""" .
+
+
+:test_bob_ar_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and append to Non-RDF resource when he is authorized read-append."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_r_nr_read_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_head_req ;
+                test:response_assertion :ok_res ;
             ]
             [
                 test:request :test_bob_r_nr_options_req ;

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -10,7 +10,7 @@
     rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations controlled by the ACL system."@en ;
     test:fixtures (
         :setup
-        :test_bob_r
+        :test_bob_r_nr
         :teardown
     ) .
 
@@ -26,24 +26,26 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_r_req ;
+                test:request :setup_alice_share_bob_r_nr_req ;
                 test:response_assertion :created_ok_res
             ]
             [
-                test:request :setup_alice_share_bob_r_acl_req ;
+                test:request :setup_alice_share_bob_r_nr_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_r_req a http:RequestMessage ;
+:setup_alice_share_bob_r_nr_req a http:RequestMessage ;
+    rdfs:comment "Set up Non-RDF resource for Bob to read.";
     http:method "PUT" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> ;
     httph:content_type "text/plain" ;
     http:content "protected contents, that Alice gives Bob Read to." .
 
 
-:setup_alice_share_bob_r_acl_req a http:RequestMessage ;
+:setup_alice_share_bob_r_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read.";
     http:method "PUT" ;
     http:requestURI </test-auth/alice_share_bob_r.txt.acl> ;
     httph:content_type "text/turtle" ;
@@ -58,67 +60,67 @@
   acl:mode acl:Read.
 """ .
 
-:test_bob_r a test:AutomatedTest ;
-    test:purpose "Check that Bob can only read when he is authorized read only."@en ;
+:test_bob_r_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can only read Non-RDF resource when he is authorized read only."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_r_r_req ;
+                test:request :test_bob_r_nr_r_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_r_w_req ;
+                test:request :test_bob_r_nr_w_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_p_req ;
+                test:request :test_bob_r_nr_p_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_a_req ;
+                test:request :test_bob_r_nr_a_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_d_req ;
+                test:request :test_bob_r_nr_d_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_o_req ;
+                test:request :test_bob_r_nr_o_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
     ] .
 
 
-:test_bob_r_r_req a http:RequestMessage ;
+:test_bob_r_nr_r_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_w_req a http:RequestMessage ;
+:test_bob_r_nr_w_req a http:RequestMessage ;
     http:method "PUT" ;
     http:content "Bob's replacement"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_p_req a http:RequestMessage ;
+:test_bob_r_nr_p_req a http:RequestMessage ;
     http:method "PATCH" ;
     http:content "+Bob's patch"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_a_req a http:RequestMessage ;
+:test_bob_r_nr_a_req a http:RequestMessage ;
     http:method "POST" ;
     http:content "Bob's addition"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_d_req a http:RequestMessage ;
+:test_bob_r_nr_d_req a http:RequestMessage ;
     http:method "DELETE" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_o_req a http:RequestMessage ;
+:test_bob_r_nr_o_req a http:RequestMessage ;
     http:method "DAHU" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -65,16 +65,63 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_r_req ;
+                test:request :test_bob_r_r_req ;
                 test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_r_w_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_p_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_a_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_d_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_o_req ;
+                test:response_assertion :invalid_req_res ;
             ]
         )
     ] .
 
 
-:test_bob_r_req a http:RequestMessage ;
+:test_bob_r_r_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:test_bob_r_w_req a http:RequestMessage ;
+    http:method "PUT" ;
+    http:content "Bob's replacement"@en ;
+    httph:content_type "text/plain" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:test_bob_r_p_req a http:RequestMessage ;
+    http:method "PATCH" ;
+    http:content "+Bob's patch"@en ;
+    httph:content_type "text/plain" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:test_bob_r_a_req a http:RequestMessage ;
+    http:method "POST" ;
+    http:content "Bob's addition"@en ;
+    httph:content_type "text/plain" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:test_bob_r_d_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:test_bob_r_o_req a http:RequestMessage ;
+    http:method "DAHU" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
 
 :created_ok_res a http:ResponseMessage ;
     http:status 201 .
@@ -82,7 +129,11 @@
 :ok_res a http:ResponseMessage ;
     http:status 200 .
 
+:forbidden_res a http:ResponseMessage ;
+    http:status 403 .
 
+:invalid_req_res a http:ResponseMessage ;
+    http:status 400 . # https://github.com/solid/specification/issues/117
 
 
 

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -75,6 +75,10 @@
                 test:response_assertion :ok_res ;
             ]
             [
+                test:request :test_bob_r_nr_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
                 test:request :test_bob_r_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
@@ -106,6 +110,10 @@
     http:method "HEAD" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
+:test_bob_r_nr_options_req a http:RequestMessage ;
+    http:method "OPTIONS" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
 :test_bob_r_nr_write_req a http:RequestMessage ;
     http:method "PUT" ;
     http:content "Bob's replacement"@en ;
@@ -135,6 +143,9 @@
 
 :created_ok_res a http:ResponseMessage ;
     http:status 201 .
+
+:no_content_res a http:ResponseMessage ;
+    http:status 204 .
 
 :ok_res a http:ResponseMessage ;
     http:status 200 .

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -39,7 +39,7 @@
 :setup_alice_share_bob_r_nr_req a http:RequestMessage ;
     rdfs:comment "Set up Non-RDF resource for Bob to read.";
     http:method "PUT" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> ;
+    http:requestURI </test-auth/alice_share_bob.txt> ;
     httph:content_type "text/plain" ;
     http:content "protected contents, that Alice gives Bob Read to." .
 
@@ -47,16 +47,16 @@
 :setup_alice_share_bob_r_nr_acl_req a http:RequestMessage ;
     rdfs:comment "Set up ACL for Non-RDF resource for Bob to read.";
     http:method "PUT" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt.acl> ;
+    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob_r.txt>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob_r.txt>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
   acl:mode acl:Read.
 """ .
 
@@ -104,41 +104,41 @@
 
 :test_bob_r_nr_read_req a http:RequestMessage ;
     http:method "GET" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :test_bob_r_nr_head_req a http:RequestMessage ;
     http:method "HEAD" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :test_bob_r_nr_options_req a http:RequestMessage ;
     http:method "OPTIONS" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :test_bob_r_nr_write_req a http:RequestMessage ;
     http:method "PUT" ;
     http:content "Bob's replacement"@en ;
     httph:content_type "text/plain" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :test_bob_r_nr_patch_req a http:RequestMessage ;
     http:method "PATCH" ;
     http:content "+Bob's patch"@en ;
     httph:content_type "text/plain" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :test_bob_r_nr_append_req a http:RequestMessage ;
     http:method "POST" ;
     http:content "Bob's addition"@en ;
     httph:content_type "text/plain" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :test_bob_r_nr_delete_req a http:RequestMessage ;
     http:method "DELETE" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :test_bob_r_nr_other_req a http:RequestMessage ;
     http:method "DAHU" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 
 :created_ok_res a http:ResponseMessage ;
@@ -184,12 +184,12 @@
 
 :teardown_alice_share_bob_r_req a http:RequestMessage ;
     http:method "DELETE" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt> .
+    http:requestURI </test-auth/alice_share_bob.txt> .
 
 :teardown_alice_share_bob_r_acl_req a http:RequestMessage ;
     rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
     http:method "DELETE" ;
-    http:requestURI </test-auth/alice_share_bob_r.txt.acl> .
+    http:requestURI </test-auth/alice_share_bob.txt.acl> .
 
 :teardown_test_dir a http:RequestMessage ;
     rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -1,0 +1,128 @@
+@prefix test: <http://ontologi.es/doap-tests#> .
+@prefix deps: <http://ontologi.es/doap-deps#>.
+@prefix httph:<http://www.w3.org/2007/ont/httph#> .
+@prefix http: <http://www.w3.org/2007/ont/http#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl#> .
+
+:test_list a test:FixtureTable ;
+    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations controlled by the ACL system."@en ;
+    test:fixtures (
+        :setup
+        :test_bob_r
+        :teardown
+    ) .
+
+<http://example.org/httplist#http_req_res_list>
+    a nfo:SoftwareItem ;
+    deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+    nfo:definesFunction "http_req_res_list" .
+
+:setup a test:AutomatedTest ;
+    test:purpose "Set up resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_r_req ;
+                test:response_assertion :created_ok_res
+            ]
+            [
+                test:request :setup_alice_share_bob_r_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_r_req a http:RequestMessage ;
+    http:method "PUT" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> ;
+    httph:content_type "text/plain" ;
+    http:content "protected contents, that Alice gives Bob Read to." .
+
+
+:setup_alice_share_bob_r_acl_req a http:RequestMessage ;
+    http:method "PUT" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob_r.txt>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob_r.txt>;
+  acl:mode acl:Read.
+""" .
+
+:test_bob_r a test:AutomatedTest ;
+    test:purpose "Check that Bob can only read when he is authorized read only."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_r_req ;
+                test:response_assertion :ok_res ;
+            ]
+        )
+    ] .
+
+
+:test_bob_r_req a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:created_ok_res a http:ResponseMessage ;
+    http:status 201 .
+
+:ok_res a http:ResponseMessage ;
+    http:status 200 .
+
+
+
+
+
+
+
+:teardown a test:AutomatedTest ;
+    test:purpose "Delete resources that were set up in these tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :teardown_alice_share_bob_r_req ;
+                test:response_assertion :deleted_ok_res
+            ]
+            [
+                test:request :teardown_alice_share_bob_r_acl_req ;
+                test:response_assertion :deleted_ok_res
+            ]
+            [
+                test:request :teardown_test_dir ;
+                test:response_assertion :deleted_ok_res
+            ]
+
+        )
+    ] .
+
+:teardown_alice_share_bob_r_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:teardown_alice_share_bob_r_acl_req a http:RequestMessage ;
+    rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
+    http:method "DELETE" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt.acl> .
+
+:teardown_test_dir a http:RequestMessage ;
+    rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
+    http:method "DELETE" ;
+    http:requestURI </test-auth/> .
+
+:deleted_ok_res a http:ResponseMessage ;
+    http:status 200 .

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -71,6 +71,10 @@
                 test:response_assertion :ok_res ;
             ]
             [
+                test:request :test_bob_r_nr_h_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
                 test:request :test_bob_r_nr_w_req ;
                 test:response_assertion :forbidden_res ;
             ]
@@ -96,6 +100,10 @@
 
 :test_bob_r_nr_r_req a http:RequestMessage ;
     http:method "GET" ;
+    http:requestURI </test-auth/alice_share_bob_r.txt> .
+
+:test_bob_r_nr_h_req a http:RequestMessage ;
+    http:method "HEAD" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
 :test_bob_r_nr_w_req a http:RequestMessage ;

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -9,8 +9,10 @@
 :test_list a test:FixtureTable ;
     rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations controlled by the ACL system."@en ;
     test:fixtures (
-        :setup
+        :setup_init
         :test_bob_r_nr
+        :setup_append
+        :test_bob_a_nr
         :teardown
     ) .
 
@@ -19,8 +21,8 @@
     deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
     nfo:definesFunction "http_req_res_list" .
 
-:setup a test:AutomatedTest ;
-    test:purpose "Set up resources as needed by the rest of the tests"@en ;
+:setup_init a test:AutomatedTest ;
+    test:purpose "Set up initial resources as needed by the rest of the tests"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
@@ -102,6 +104,79 @@
     ] .
 
 
+
+:setup_append a test:AutomatedTest ;
+    test:purpose "Modify ACL to add append only to resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_a_nr_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_a_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read.";
+    http:method "PUT" ;
+    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:mode acl:Append.
+""" .
+
+
+:test_bob_a_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can only append to Non-RDF resource when he is authorized append only."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_r_nr_read_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_head_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_write_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_patch_req ;
+                test:response_assertion :unsupported_media_type_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_delete_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_r_nr_other_req ;
+                test:response_assertion :invalid_req_res ;
+            ]
+        )
+    ] .
+
+
 :test_bob_r_nr_read_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
@@ -153,11 +228,14 @@
 :forbidden_res a http:ResponseMessage ;
     http:status 403 .
 
+:not_found_res a http:ResponseMessage ;
+    http:status 404 .
+
 :invalid_req_res a http:ResponseMessage ;
     http:status 400 . # https://github.com/solid/specification/issues/117
 
-
-
+:unsupported_media_type_res a http:ResponseMessage ;
+    http:status 415 .
 
 
 :teardown a test:AutomatedTest ;

--- a/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
+++ b/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl
@@ -67,68 +67,68 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_r_nr_r_req ;
+                test:request :test_bob_r_nr_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_r_nr_h_req ;
+                test:request :test_bob_r_nr_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_r_nr_w_req ;
+                test:request :test_bob_r_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_p_req ;
+                test:request :test_bob_r_nr_patch_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_a_req ;
+                test:request :test_bob_r_nr_append_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_d_req ;
+                test:request :test_bob_r_nr_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_r_nr_o_req ;
+                test:request :test_bob_r_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
     ] .
 
 
-:test_bob_r_nr_r_req a http:RequestMessage ;
+:test_bob_r_nr_read_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_nr_h_req a http:RequestMessage ;
+:test_bob_r_nr_head_req a http:RequestMessage ;
     http:method "HEAD" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_nr_w_req a http:RequestMessage ;
+:test_bob_r_nr_write_req a http:RequestMessage ;
     http:method "PUT" ;
     http:content "Bob's replacement"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_nr_p_req a http:RequestMessage ;
+:test_bob_r_nr_patch_req a http:RequestMessage ;
     http:method "PATCH" ;
     http:content "+Bob's patch"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_nr_a_req a http:RequestMessage ;
+:test_bob_r_nr_append_req a http:RequestMessage ;
     http:method "POST" ;
     http:content "Bob's addition"@en ;
     httph:content_type "text/plain" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_nr_d_req a http:RequestMessage ;
+:test_bob_r_nr_delete_req a http:RequestMessage ;
     http:method "DELETE" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 
-:test_bob_r_nr_o_req a http:RequestMessage ;
+:test_bob_r_nr_other_req a http:RequestMessage ;
     http:method "DAHU" ;
     http:requestURI </test-auth/alice_share_bob_r.txt> .
 

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
@@ -30,7 +30,7 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_r_nr_req ;
+                test:request :setup_alice_share_bob_nr_req ;
                 test:response_assertion :created_ok_res
             ]
             [
@@ -40,8 +40,8 @@
         )
     ] .
 
-:setup_alice_share_bob_r_nr_req a http:RequestMessage ;
-    rdfs:comment "Set up Non-RDF resource for Bob to read.";
+:setup_alice_share_bob_nr_req a http:RequestMessage ;
+    rdfs:comment "Set up Non-RDF resource for Bob.";
     http:method "PUT" ;
     http:requestURI </test-auth/alice_share_bob.txt> ;
     httph:content_type "text/plain" ;

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
@@ -17,6 +17,8 @@
         :test_bob_ar_nr
         :setup_read_write
         :test_bob_rw_nr
+        :setup_read_write_container
+        :test_bob_delete_nr
         :teardown
     ) .
 
@@ -325,6 +327,48 @@
     ] .
 
 
+:setup_read_write_container a test:AutomatedTest ;
+    test:purpose "Modify ACL to add write and read to the container as needed to delete resource"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_rw_container_nr_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_rw_container_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
+    http:method "PUT" ;
+    http:requestURI </test-auth/.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/>;
+  acl:mode acl:Read, acl:Write.
+""" .
+
+:test_bob_delete_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can delete Non-RDF resource when he is authorized read-write on the container."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_nr_delete_req ;
+                test:response_assertion :deleted_ok_res ;
+            ]
+        )
+    ] .
+
 :test_bob_nr_read_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </test-auth/alice_share_bob.txt> .
@@ -392,10 +436,6 @@
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
-            [
-                test:request :teardown_alice_share_bob_req ;
-                test:response_assertion :deleted_ok_res
-            ]
             [
                 test:request :teardown_alice_share_bob_acl_req ;
                 test:response_assertion :deleted_ok_res

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
@@ -15,6 +15,8 @@
         :test_bob_a_nr
         :setup_read_append
         :test_bob_ar_nr
+        :setup_read_write
+        :test_bob_rw_nr
         :teardown
     ) .
 
@@ -247,6 +249,77 @@
             [
                 test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
+            ]
+        )
+    ] .
+
+:setup_read_write a test:AutomatedTest ;
+    test:purpose "Modify ACL to add write and read to resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_rw_nr_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_rw_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
+    http:method "PUT" ;
+    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:mode acl:Read, acl:Write.
+""" .
+
+
+:test_bob_rw_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and write to Non-RDF resource when he is authorized read-write."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_nr_read_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_nr_head_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_nr_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
+                test:request :test_bob_nr_write_req ;
+                test:response_assertion :created_res ; # TODO: Really?
+            ]
+            [
+                test:request :test_bob_nr_patch_req ;
+                test:response_assertion :unsupported_media_type_res ;
+            ]
+            [
+                test:request :test_bob_nr_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_nr_other_req ;
+                test:response_assertion :invalid_req_res ;
+            ]
+            [
+                test:request :test_bob_nr_delete_req ;
+                test:response_assertion :forbidden_res ; # Because Bob doesn't have write permission on the container
             ]
         )
     ] .

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
@@ -429,6 +429,9 @@
 :unsupported_media_type_res a http:ResponseMessage ;
     http:status 415 .
 
+:deleted_ok_res a http:ResponseMessage ;
+    http:status 200 .
+
 
 :teardown a test:AutomatedTest ;
     test:purpose "Delete resources that were set up in these tests"@en ;
@@ -443,6 +446,10 @@
             [
                 test:request :teardown_test_dir ;
                 test:response_assertion :deleted_ok_res
+            ]
+            [
+                test:request :teardown_verify_its_gone ;
+                test:response_assertion :not_found_res
             ]
 
         )
@@ -462,5 +469,6 @@
     http:method "DELETE" ;
     http:requestURI </test-auth/> .
 
-:deleted_ok_res a http:ResponseMessage ;
-    http:status 200 .
+:teardown_verify_its_gone a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </test-auth/> .

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
@@ -7,7 +7,7 @@
 @prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl#> .
 
 :test_list a test:FixtureTable ;
-    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations controlled by the ACL system."@en ;
+    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on an LDP-NR controlled by the ACL system."@en ;
     test:fixtures (
         :setup_init
         :test_bob_r_nr
@@ -47,7 +47,7 @@
 :setup_alice_share_bob_nr_req a http:RequestMessage ;
     rdfs:comment "Set up Non-RDF resource for Bob.";
     http:method "PUT" ;
-    http:requestURI </test-auth/alice_share_bob.txt> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> ;
     httph:content_type "text/plain" ;
     http:content "protected contents, that Alice gives Bob Read to." .
 
@@ -55,16 +55,16 @@
 :setup_alice_share_bob_r_nr_acl_req a http:RequestMessage ;
     rdfs:comment "Set up ACL for Non-RDF resource for Bob to read.";
     http:method "PUT" ;
-    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read.
 """ .
 
@@ -127,16 +127,16 @@
 :setup_alice_share_bob_a_nr_acl_req a http:RequestMessage ;
     rdfs:comment "Set up ACL for Non-RDF resource for Bob to append.";
     http:method "PUT" ;
-    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Append.
 """ .
 
@@ -200,16 +200,16 @@
 :setup_alice_share_bob_ar_nr_acl_req a http:RequestMessage ;
     rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and append.";
     http:method "PUT" ;
-    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Append.
 """ .
 
@@ -271,16 +271,16 @@
 :setup_alice_share_bob_rw_nr_acl_req a http:RequestMessage ;
     rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
     http:method "PUT" ;
-    http:requestURI </test-auth/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/alice_share_bob.txt>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write.
 """ .
 
@@ -343,16 +343,16 @@
 :setup_alice_share_bob_rw_container_nr_acl_req a http:RequestMessage ;
     rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
     http:method "PUT" ;
-    http:requestURI </test-auth/.acl> ;
+    http:requestURI </test-auth-nr/.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/>;
+  acl:accessTo </test-auth-nr/>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth/>;
+  acl:accessTo </test-auth-nr/>;
   acl:mode acl:Read, acl:Write.
 """ .
 
@@ -371,41 +371,41 @@
 
 :test_bob_nr_read_req a http:RequestMessage ;
     http:method "GET" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :test_bob_nr_head_req a http:RequestMessage ;
     http:method "HEAD" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :test_bob_nr_options_req a http:RequestMessage ;
     http:method "OPTIONS" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :test_bob_nr_write_req a http:RequestMessage ;
     http:method "PUT" ;
     http:content "Bob's replacement"@en ;
     httph:content_type "text/plain" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :test_bob_nr_patch_req a http:RequestMessage ;
     http:method "PATCH" ;
     http:content "+Bob's patch"@en ;
     httph:content_type "text/plain" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :test_bob_nr_append_req a http:RequestMessage ;
     http:method "POST" ;
     http:content "Bob's addition"@en ;
     httph:content_type "text/plain" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :test_bob_nr_delete_req a http:RequestMessage ;
     http:method "DELETE" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :test_bob_nr_other_req a http:RequestMessage ;
     http:method "DAHU" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 
 :created_ok_res a http:ResponseMessage ;
@@ -457,18 +457,18 @@
 
 :teardown_alice_share_bob_req a http:RequestMessage ;
     http:method "DELETE" ;
-    http:requestURI </test-auth/alice_share_bob.txt> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 :teardown_alice_share_bob_acl_req a http:RequestMessage ;
     rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
     http:method "DELETE" ;
-    http:requestURI </test-auth/alice_share_bob.txt.acl> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> .
 
 :teardown_test_dir a http:RequestMessage ;
     rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
     http:method "DELETE" ;
-    http:requestURI </test-auth/> .
+    http:requestURI </test-auth-nr/> .
 
 :teardown_verify_its_gone a http:RequestMessage ;
     http:method "GET" ;
-    http:requestURI </test-auth/> .
+    http:requestURI </test-auth-nr/> .

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl
@@ -4,7 +4,7 @@
 @prefix http: <http://www.w3.org/2007/ont/http#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
-@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/basic-controlled-operations.ttl#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl#> .
 
 :test_list a test:FixtureTable ;
     rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations controlled by the ACL system."@en ;

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_rs.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_rs.ttl
@@ -1,0 +1,480 @@
+@prefix test: <http://ontologi.es/doap-tests#> .
+@prefix deps: <http://ontologi.es/doap-deps#>.
+@prefix httph:<http://www.w3.org/2007/ont/httph#> .
+@prefix http: <http://www.w3.org/2007/ont/http#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_rs.ttl#> .
+
+:test_list a test:FixtureTable ;
+    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on an LDP-RS controlled by the ACL system."@en ;
+    test:fixtures (
+        :setup_init
+        :test_bob_r_rs
+        :setup_append
+        :test_bob_a_rs
+        :setup_read_append
+        :test_bob_ar_rs
+        :setup_read_write
+        :test_bob_rw_rs
+        :setup_read_write_container
+        :test_bob_delete_rs
+        :teardown
+    ) .
+
+<http://example.org/httplist#http_req_res_list>
+    a nfo:SoftwareItem ;
+    deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
+    nfo:definesFunction "http_req_res_list" .
+
+:setup_init a test:AutomatedTest ;
+    test:purpose "Set up initial resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_rs_req ;
+                test:response_assertion :created_ok_res
+            ]
+            [
+                test:request :setup_alice_share_bob_r_rs_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_rs_req a http:RequestMessage ;
+    rdfs:comment "Set up RDF resource for Bob.";
+    http:method "PUT" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+<> rdfs:comment "Protected contents, that Alice gives Bob Read to." .
+    """ .
+
+
+:setup_alice_share_bob_r_rs_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for RDF resource for Bob to read.";
+    http:method "PUT" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Read.
+""" .
+
+:test_bob_r_rs a test:AutomatedTest ;
+    test:purpose "Check that Bob can only read RDF resource when he is authorized read only."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_rs_read_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_rs_head_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_rs_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
+                test:request :test_bob_rs_write_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_patch_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_append_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_delete_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_other_req ;
+                test:response_assertion :invalid_req_res ;
+            ]
+        )
+    ] .
+
+
+
+:setup_append a test:AutomatedTest ;
+    test:purpose "Modify ACL to add append only to resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_a_rs_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_a_rs_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for RDF resource for Bob to append.";
+    http:method "PUT" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Append.
+""" .
+
+
+:test_bob_a_rs a test:AutomatedTest ;
+    test:purpose "Check that Bob can only append to RDF resource when he is authorized append only."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_rs_read_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_head_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
+                test:request :test_bob_rs_write_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_patch_req ;
+                test:response_assertion :ok_res ; # TODO: Check deletes
+            ]
+            [
+                test:request :test_bob_rs_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_rs_delete_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_other_req ;
+                test:response_assertion :invalid_req_res ;
+            ]
+        )
+    ] .
+
+
+
+:setup_read_append a test:AutomatedTest ;
+    test:purpose "Modify ACL to add append and read to resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_ar_rs_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_ar_rs_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for RDF resource for Bob to read and append.";
+    http:method "PUT" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Read, acl:Append.
+""" .
+
+
+:test_bob_ar_rs a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and append to RDF resource when he is authorized read-append."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_rs_read_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_rs_head_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_rs_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
+                test:request :test_bob_rs_write_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_patch_req ;
+                test:response_assertion :ok_res ; # TODO: Check deletes
+            ]
+            [
+                test:request :test_bob_rs_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_rs_delete_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_rs_other_req ;
+                test:response_assertion :invalid_req_res ;
+            ]
+        )
+    ] .
+
+:setup_read_write a test:AutomatedTest ;
+    test:purpose "Modify ACL to add write and read to resources as needed by the rest of the tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_rw_rs_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_rw_rs_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for RDF resource for Bob to read and write.";
+    http:method "PUT" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/alice_share_bob.ttl>;
+  acl:mode acl:Read, acl:Write.
+""" .
+
+
+:test_bob_rw_rs a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and write to RDF resource when he is authorized read-write."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_rs_read_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_rs_head_req ;
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_rs_options_req ;
+                test:response_assertion :no_content_res ;
+            ]
+            [
+                test:request :test_bob_rs_write_req ;
+                test:response_assertion :created_res ; # TODO: Really?
+            ]
+            [
+                test:request :test_bob_rs_patch_req ;
+                test:response_assertion :ok_res ; # TODO: Check deletes
+            ]
+            [
+                test:request :test_bob_rs_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_rs_other_req ;
+                test:response_assertion :invalid_req_res ;
+            ]
+            [
+                test:request :test_bob_rs_delete_req ;
+                test:response_assertion :forbidden_res ; # Because Bob doesn't have write permission on the container
+            ]
+        )
+    ] .
+
+
+:setup_read_write_container a test:AutomatedTest ;
+    test:purpose "Modify ACL to add write and read to the container as needed to delete resource"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :setup_alice_share_bob_rw_container_rs_acl_req ;
+                test:response_assertion :created_ok_res
+            ]
+        )
+    ] .
+
+:setup_alice_share_bob_rw_container_rs_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for RDF resource for Bob to read and write.";
+    http:method "PUT" ;
+    http:requestURI </test-auth-rs/.acl> ;
+    httph:content_type "text/turtle" ;
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-rs/>;
+  acl:mode acl:Read, acl:Write.
+""" .
+
+:test_bob_delete_rs a test:AutomatedTest ;
+    test:purpose "Check that Bob can delete RDF resource when he is authorized read-write on the container."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_rs_delete_req ;
+                test:response_assertion :deleted_ok_res ;
+            ]
+        )
+    ] .
+
+:test_bob_rs_read_req a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_head_req a http:RequestMessage ;
+    http:method "HEAD" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_options_req a http:RequestMessage ;
+    http:method "OPTIONS" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_write_req a http:RequestMessage ;
+    http:method "PUT" ;
+    http:content """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+<> rdfs:comment "Bob replaced it." .
+    """ ;
+    httph:content_type "text/turtle" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_patch_req a http:RequestMessage ;
+    http:method "PATCH" ;
+    http:content "INSERT DATA { <> a <http://example.org/foo> . }" ;
+    httph:content_type "application/sparql-update" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_append_req a http:RequestMessage ;
+    http:method "POST" ;
+    http:content """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+<> rdfs:comment "Bob added this."
+    """ ;
+    httph:content_type "text/turtle" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_delete_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_other_req a http:RequestMessage ;
+    http:method "DAHU" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+
+:created_ok_res a http:ResponseMessage ;
+    http:status 201 .
+
+:no_content_res a http:ResponseMessage ;
+    http:status 204 .
+
+:ok_res a http:ResponseMessage ;
+    http:status 200 .
+
+:forbidden_res a http:ResponseMessage ;
+    http:status 403 .
+
+:not_found_res a http:ResponseMessage ;
+    http:status 404 .
+
+:invalid_req_res a http:ResponseMessage ;
+    http:status 400 . # https://github.com/solid/specification/issues/117
+
+:unsupported_media_type_res a http:ResponseMessage ;
+    http:status 415 .
+
+:deleted_ok_res a http:ResponseMessage ;
+    http:status 200 .
+
+
+:teardown a test:AutomatedTest ;
+    test:purpose "Delete resources that were set up in these tests"@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :teardown_alice_share_bob_acl_req ;
+                test:response_assertion :deleted_ok_res
+            ]
+            [
+                test:request :teardown_test_dir ;
+                test:response_assertion :deleted_ok_res
+            ]
+            [
+                test:request :teardown_verify_its_gone ;
+                test:response_assertion :not_found_res
+            ]
+
+        )
+    ] .
+
+:teardown_alice_share_bob_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:teardown_alice_share_bob_acl_req a http:RequestMessage ;
+    rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
+    http:method "DELETE" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl.acl> .
+
+:teardown_test_dir a http:RequestMessage ;
+    rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
+    http:method "DELETE" ;
+    http:requestURI </test-auth-rs/> .
+
+:teardown_verify_its_gone a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </test-auth-rs/> .

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_rs.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_rs.ttl
@@ -97,6 +97,10 @@
                 test:response_assertion :forbidden_res ;
             ]
             [
+                test:request :test_bob_rs_patch_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
                 test:request :test_bob_rs_append_req ;
                 test:response_assertion :forbidden_res ;
             ]
@@ -167,7 +171,11 @@
             ]
             [
                 test:request :test_bob_rs_patch_req ;
-                test:response_assertion :ok_res ; # TODO: Check deletes
+                test:response_assertion :ok_res ;
+            ]
+            [
+                test:request :test_bob_rs_patch_with_delete_req ;
+                test:response_assertion :forbidden_res ;
             ]
             [
                 test:request :test_bob_rs_append_req ;
@@ -240,9 +248,12 @@
             ]
             [
                 test:request :test_bob_rs_patch_req ;
-                test:response_assertion :ok_res ; # TODO: Check deletes
+                test:response_assertion :ok_res ;
             ]
             [
+                test:request :test_bob_rs_patch_with_delete_req ;
+                test:response_assertion :forbidden_res ;
+            ]            [
                 test:request :test_bob_rs_append_req ;
                 test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
             ]
@@ -312,6 +323,10 @@
             [
                 test:request :test_bob_rs_patch_req ;
                 test:response_assertion :ok_res ; # TODO: Check deletes
+            ]
+            [
+                test:request :test_bob_rs_patch_with_delete_req ;
+                test:response_assertion :ok_res ;
             ]
             [
                 test:request :test_bob_rs_append_req ;
@@ -393,7 +408,14 @@
 
 :test_bob_rs_patch_req a http:RequestMessage ;
     http:method "PATCH" ;
-    http:content "INSERT DATA { <> a <http://example.org/foo> . }" ;
+    http:content "INSERT DATA { <> a <http://example.org/Foo> . }" ;
+    httph:content_type "application/sparql-update" ;
+    http:requestURI </test-auth-rs/alice_share_bob.ttl> .
+
+:test_bob_rs_patch_with_delete_req a http:RequestMessage ;
+    http:method "PATCH" ;
+    http:content """DELETE { ?s a ?o . } INSERT { <> a <http://example.org/Bar> . }
+WHERE  { ?s a ?o . }""" ;
     httph:content_type "application/sparql-update" ;
     http:requestURI </test-auth-rs/alice_share_bob.ttl> .
 

--- a/testers/rdf-fixtures/run-scripts/acl-test-basic.t
+++ b/testers/rdf-fixtures/run-scripts/acl-test-basic.t
@@ -39,6 +39,10 @@ use Test::More;
 use Test::FITesque;
 use Test::FITesque::Test;
 
+BEGIN {
+  $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = 'IO::Socket::SSL';
+}
+
 my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;

--- a/testers/rdf-fixtures/run-scripts/authentication.t
+++ b/testers/rdf-fixtures/run-scripts/authentication.t
@@ -39,6 +39,11 @@ use Test::More;
 use Test::FITesque;
 use Test::FITesque::Test;
 
+BEGIN {
+  $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = 'IO::Socket::SSL';
+}
+
+
 my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;

--- a/testers/rdf-fixtures/run-scripts/authentication.t
+++ b/testers/rdf-fixtures/run-scripts/authentication.t
@@ -48,7 +48,7 @@ my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;
 
-my @files = ('authentication.ttl','operations_protected_ldp_nr.ttl');
+my @files = ('authentication.ttl','operations_protected_ldp_nr.ttl','operations_protected_ldp_rs.ttl');
 
 
 BAIL_OUT("Set SOLID_REMOTE_BASE to the URL of the base of the server you are testing") unless $ENV{SOLID_REMOTE_BASE};

--- a/testers/rdf-fixtures/run-scripts/authentication.t
+++ b/testers/rdf-fixtures/run-scripts/authentication.t
@@ -43,7 +43,7 @@ my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;
 
-my @files = ('authentication.ttl','basic-controlled-operations.ttl');
+my @files = ('authentication.ttl','operations_protected_ldp_nr.ttl');
 
 
 BAIL_OUT("Set SOLID_REMOTE_BASE to the URL of the base of the server you are testing") unless $ENV{SOLID_REMOTE_BASE};

--- a/testers/rdf-fixtures/run-scripts/authentication.t
+++ b/testers/rdf-fixtures/run-scripts/authentication.t
@@ -43,9 +43,18 @@ my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;
 
+my @files = ('authentication.ttl','basic-controlled-operations.ttl');
+
+
 BAIL_OUT("Set SOLID_REMOTE_BASE to the URL of the base of the server you are testing") unless $ENV{SOLID_REMOTE_BASE};
 
-my $suite = Test::FITesque::RDF->new(source => $path . 'authentication.ttl', base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
+
+my $suite = Test::FITesque::Suite->new;
+
+foreach my $file (@files) {
+  note("Reading tests from $path$file");
+  $suite->add(Test::FITesque::RDF->new(source => $path . $file, base_uri => $ENV{SOLID_REMOTE_BASE})->suite);
+}
 
 $suite->run_tests;
 

--- a/testers/rdf-fixtures/run-scripts/basic.t
+++ b/testers/rdf-fixtures/run-scripts/basic.t
@@ -40,6 +40,10 @@ use Test::More;
 use Test::FITesque;
 use Test::FITesque::Test;
 
+BEGIN {
+  $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = 'IO::Socket::SSL';
+}
+
 my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;


### PR DESCRIPTION
This PR is a result of several rounds of experiments to go through the HTTP operations that can be done on a resource, with several combinations of read, write and append authorizations.

It tries to balance readability with power and reusability, and it is currently designed to pass on NSS5, even though that means passing on things that are pretty clearly NSS bugs. The rationale for this is that we want to have a clear idea of the actual behaviour of NSS, so that we can see if we will make changes that are breaking things in the new spec work.

The first iteration tests LDP-NR, i.e. non-rdf resources. The idea is to copy and modify that into similar files for other LDP types.