### PR TITLE
Fix README.md for crash avoidance and portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ docker build -t table-reporter reporters/table
 docker network create testnet
 mkdir  -p reports
 
-./runTests.sh gold
-./runTests.sh inrupt-pod-server
-./runTests.sh node-solid-server
-./runTests.sh trellis
-./runTests.sh wac-ldp
-# ./runTests.sh rww-play
+bash runTests.sh gold
+bash runTests.sh inrupt-pod-server
+bash runTests.sh node-solid-server
+bash runTests.sh trellis
+bash runTests.sh wac-ldp
+# bash runTests.sh rww-play
 
 egrep 'Tests:|tests run:|earl:outcome' reports/* | docker run -i table-reporter
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ mkdir  -p reports
 ./runTests.sh wac-ldp
 # ./runTests.sh rww-play
 
-egrep '[Tt]ests|earl:outcome' reports/* | docker run -i table-reporter
+egrep 'Tests:|tests run:|earl:outcome' reports/* | docker run -i table-reporter
 ```
 The final output should look something like:
 ```sh


### PR DESCRIPTION
As I want to support other users of this test suite, not to run into the same problems as I, here some minor modifications to the README.
A user following the new README will avoid 

- the crash of the `table-reporter`
- the not-recognizing of Trellis server on non-bash systems.

I structured them into 2 commits, if you want to cherry-pick.