### PR TITLE
Clean up run scripts

### DIFF
--- a/testers/rdf-fixtures/fixture-tables/operations_protected_cont.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_cont.ttl
@@ -4,21 +4,19 @@
 @prefix http: <http://www.w3.org/2007/ont/http#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
-@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_nr.ttl#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_cont.ttl#> .
 
 :test_list a test:FixtureTable ;
-    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on an LDP-NR controlled by the ACL system."@en ;
+    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on a container controlled by the ACL system with unspecified interaction model."@en ;
     test:fixtures (
         :setup_init
-        :test_bob_r_nr
+        :test_bob_r_bc
         :setup_append
-        :test_bob_a_nr
+        :test_bob_a_bc
         :setup_read_append
-        :test_bob_ar_nr
+        :test_bob_ar_bc
         :setup_read_write
-        :test_bob_rw_nr
-        :setup_read_write_container
-        :test_bob_delete_nr
+        :test_bob_rw_bc
         :teardown
     ) .
 
@@ -34,76 +32,86 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_nr_req ;
+                test:request :setup_alice_share_bob_bc_req ;
                 test:response_assertion :created_ok_res
             ]
             [
-                test:request :setup_alice_share_bob_r_nr_acl_req ;
+                test:request :setup_alice_share_bob_r_bc_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_nr_req a http:RequestMessage ;
-    rdfs:comment "Set up Non-RDF resource for Bob.";
-    http:method "PUT" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> ;
-    httph:content_type "text/plain" ;
-    http:content "protected contents, that Alice gives Bob Read to." .
+:setup_alice_share_bob_bc_req a http:RequestMessage ;
+    rdfs:comment "Set up RDF BC resource for Bob.";
+    http:method "POST" ;
+    http:requestURI </> ;
+    httph:slug "test-auth-bc" ;
+    httph:content_type "text/turtle";
+    httph:link """<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"""";
+    http:content """@prefix dc: <http://purl.org/dc/terms/>.
+@prefix ldp: <http://www.w3.org/ns/ldp#>.
+<> a ldp:BasicContainer ;
+   dc:title "Initial container for Bobs stuff"@en .""" .
 
 
-:setup_alice_share_bob_r_nr_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read.";
+
+:setup_alice_share_bob_r_bc_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Basic Container for Bob to read.";
     http:method "PUT" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-bc/.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Read.
 """ .
 
-:test_bob_r_nr a test:AutomatedTest ;
-    test:purpose "Check that Bob can only read Non-RDF resource when he is authorized read only."@en ;
+:test_bob_r_bc a test:AutomatedTest ;
+    test:purpose "Check that Bob can only read Basic Container when he is authorized read only."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_nr_read_req ;
+                test:request :test_bob_bc_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_nr_head_req ;
+                test:request :test_bob_bc_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_nr_options_req ;
+                test:request :test_bob_bc_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_nr_write_req ;
+                test:request :test_bob_bc_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_patch_req ;
+                test:request :test_bob_bc_patch_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_append_req ;
+                test:request :test_bob_bc_patch_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_delete_req ;
+                test:request :test_bob_bc_append_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_other_req ;
+                test:request :test_bob_bc_delete_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            [
+                test:request :test_bob_bc_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -118,65 +126,70 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_a_nr_acl_req ;
+                test:request :setup_alice_share_bob_a_bc_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_a_nr_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Non-RDF resource for Bob to append.";
+:setup_alice_share_bob_a_bc_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Basic Container for Bob to append.";
     http:method "PUT" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-bc/.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Append.
 """ .
 
 
-:test_bob_a_nr a test:AutomatedTest ;
-    test:purpose "Check that Bob can only append to Non-RDF resource when he is authorized append only."@en ;
+:test_bob_a_bc a test:AutomatedTest ;
+    test:purpose "Check that Bob can only append to Basic Container when he is authorized append only."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_nr_read_req ;
+                test:request :test_bob_bc_read_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_head_req ;
+                test:request :test_bob_bc_head_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_options_req ;
+                test:request :test_bob_bc_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_nr_write_req ;
+                test:request :test_bob_bc_write_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+             # TODO: NSS returns 500 when patching container
+            # [
+             #     test:request :test_bob_bc_patch_req ;
+             #     test:response_assertion :ok_res ;
+             # ]
+            [
+                test:request :test_bob_bc_patch_with_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_patch_req ;
-                test:response_assertion :unsupported_media_type_res ;
+                test:request :test_bob_bc_append_req ;
+                test:response_assertion :created_ok_res ;
             ]
             [
-                test:request :test_bob_nr_append_req ;
-                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
-            ]
-            [
-                test:request :test_bob_nr_delete_req ;
+                test:request :test_bob_bc_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_other_req ;
+                test:request :test_bob_bc_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -191,65 +204,70 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_ar_nr_acl_req ;
+                test:request :setup_alice_share_bob_ar_bc_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_ar_nr_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and append.";
+:setup_alice_share_bob_ar_bc_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Basic Container for Bob to read and append.";
     http:method "PUT" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-bc/.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Read, acl:Append.
 """ .
 
 
-:test_bob_ar_nr a test:AutomatedTest ;
-    test:purpose "Check that Bob can read and append to Non-RDF resource when he is authorized read-append."@en ;
+:test_bob_ar_bc a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and append to Basic Container when he is authorized read-append."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_nr_read_req ;
+                test:request :test_bob_bc_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_nr_head_req ;
+                test:request :test_bob_bc_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_nr_options_req ;
+                test:request :test_bob_bc_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_nr_write_req ;
+                test:request :test_bob_bc_write_req ;
+                test:response_assertion :forbidden_res ;
+            ]
+            # TODO: NSS returns 500 when patching container
+             # [
+             #     test:request :test_bob_bc_patch_req ;
+             #     test:response_assertion :ok_res ;
+             # ]
+            [
+                test:request :test_bob_bc_patch_with_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_patch_req ;
-                test:response_assertion :unsupported_media_type_res ;
+                test:request :test_bob_bc_append_req ;
+                test:response_assertion :created_ok ;
             ]
             [
-                test:request :test_bob_nr_append_req ;
-                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
-            ]
-            [
-                test:request :test_bob_nr_delete_req ;
+                test:request :test_bob_bc_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_nr_other_req ;
+                test:request :test_bob_bc_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -262,65 +280,70 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_rw_nr_acl_req ;
+                test:request :setup_alice_share_bob_rw_bc_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_rw_nr_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
+:setup_alice_share_bob_rw_bc_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Basic Container for Bob to read and write.";
     http:method "PUT" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
+    http:requestURI </test-auth-bc/.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
+  acl:accessTo </test-auth-bc/>;
   acl:mode acl:Read, acl:Write.
 """ .
 
 
-:test_bob_rw_nr a test:AutomatedTest ;
-    test:purpose "Check that Bob can read and write to Non-RDF resource when he is authorized read-write."@en ;
+:test_bob_rw_bc a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and write to Basic Container when he is authorized read-write."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_nr_read_req ;
+                test:request :test_bob_bc_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_nr_head_req ;
+                test:request :test_bob_bc_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_nr_options_req ;
+                test:request :test_bob_bc_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_nr_write_req ;
+                test:request :test_bob_bc_write_req ;
                 test:response_assertion :created_res ; # TODO: Really?
             ]
+            # TODO: NSS returns 500 when patching container
+             # [
+             #     test:request :test_bob_bc_patch_req ;
+             #     test:response_assertion :ok_res ; # TODO: Check deletes
+             # ]
+             # [
+             #     test:request :test_bob_bc_patch_with_delete_req ;
+             #     test:response_assertion :ok_res ;
+             # ]
             [
-                test:request :test_bob_nr_patch_req ;
-                test:response_assertion :unsupported_media_type_res ;
+                test:request :test_bob_bc_append_req ;
+                test:response_assertion :created_ok ;
             ]
             [
-                test:request :test_bob_nr_append_req ;
-                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
-            ]
-            [
-                test:request :test_bob_nr_other_req ;
+                test:request :test_bob_bc_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
             [
-                test:request :test_bob_nr_delete_req ;
+                test:request :test_bob_bc_delete_req ;
                 test:response_assertion :forbidden_res ; # Because Bob doesn't have write permission on the container
             ]
         )
@@ -334,78 +357,61 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_rw_container_nr_acl_req ;
+                test:request :setup_alice_share_bob_rw_container_bc_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_rw_container_nr_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
-    http:method "PUT" ;
-    http:requestURI </test-auth-nr/.acl> ;
-    httph:content_type "text/turtle" ;
-    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
-<#owner> a acl:Authorization;
-  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/>;
-  acl:mode acl:Read, acl:Write, acl:Control.
-<#bob> a acl:Authorization;
-  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-nr/>;
-  acl:mode acl:Read, acl:Write.
-""" .
-
-:test_bob_delete_nr a test:AutomatedTest ;
-    test:purpose "Check that Bob can delete Non-RDF resource when he is authorized read-write on the container."@en ;
-    test:test_script <http://example.org/httplist#http_req_res_list> ;
-    test:params [
-        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
-        test:steps (
-            [
-                test:request :test_bob_nr_delete_req ;
-                test:response_assertion :deleted_ok_res ;
-            ]
-        )
-    ] .
-
-:test_bob_nr_read_req a http:RequestMessage ;
+:test_bob_bc_read_req a http:RequestMessage ;
     http:method "GET" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:requestURI </test-auth-bc/> .
 
-:test_bob_nr_head_req a http:RequestMessage ;
+:test_bob_bc_head_req a http:RequestMessage ;
     http:method "HEAD" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:requestURI </test-auth-bc/> .
 
-:test_bob_nr_options_req a http:RequestMessage ;
+:test_bob_bc_options_req a http:RequestMessage ;
     http:method "OPTIONS" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:requestURI </test-auth-bc/> .
 
-:test_bob_nr_write_req a http:RequestMessage ;
+:test_bob_bc_write_req a http:RequestMessage ;
     http:method "PUT" ;
-    http:content "Bob's replacement"@en ;
-    httph:content_type "text/plain" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:content """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+<> rdfs:comment "Bob replaced it." .
+    """ ;
+    httph:content_type "text/turtle" ;
+    http:requestURI </test-auth-bc/> .
 
-:test_bob_nr_patch_req a http:RequestMessage ;
+:test_bob_bc_patch_req a http:RequestMessage ;
     http:method "PATCH" ;
-    http:content "+Bob's patch"@en ;
-    httph:content_type "text/plain" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:content "INSERT DATA { <> a <http://example.org/Foo> . }" ;
+    httph:content_type "application/sparql-update" ;
+    http:requestURI </test-auth-bc/> .
 
-:test_bob_nr_append_req a http:RequestMessage ;
+:test_bob_bc_patch_with_delete_req a http:RequestMessage ;
+    http:method "PATCH" ;
+    http:content """DELETE { ?s a ?o . } INSERT { <> a <http://example.org/Bar> . }
+WHERE  { ?s a ?o . }""" ;
+    httph:content_type "application/sparql-update" ;
+    http:requestURI </test-auth-bc/> .
+
+:test_bob_bc_append_req a http:RequestMessage ;
     http:method "POST" ;
-    http:content "Bob's addition"@en ;
-    httph:content_type "text/plain" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:content """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+<> rdfs:comment "Bob added this."
+    """ ;
+    httph:slug "bobsdata" ;
+    httph:content_type "text/turtle" ;
+    http:requestURI </test-auth-bc/> .
 
-:test_bob_nr_delete_req a http:RequestMessage ;
+:test_bob_bc_delete_req a http:RequestMessage ;
     http:method "DELETE" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:requestURI </test-auth-bc/> .
 
-:test_bob_nr_other_req a http:RequestMessage ;
+:test_bob_bc_other_req a http:RequestMessage ;
     http:method "DAHU" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+    http:requestURI </test-auth-bc/> .
 
 
 :created_ok_res a http:ResponseMessage ;
@@ -444,8 +450,8 @@
                 test:response_assertion :deleted_ok_res
             ]
             [
-                test:request :teardown_test_dir ;
-                test:response_assertion :deleted_ok_res
+                test:request :teardown_alice_share_bob_req ;
+                test:response_assertion :not_found_res
             ]
             [
                 test:request :teardown_verify_its_gone ;
@@ -455,20 +461,16 @@
         )
     ] .
 
-:teardown_alice_share_bob_req a http:RequestMessage ;
-    http:method "DELETE" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt> .
-
 :teardown_alice_share_bob_acl_req a http:RequestMessage ;
     rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
     http:method "DELETE" ;
-    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> .
+    http:requestURI </test-auth-bc/.acl> .
 
-:teardown_test_dir a http:RequestMessage ;
-    rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
+:teardown_alice_share_bob_req a http:RequestMessage ;
     http:method "DELETE" ;
-    http:requestURI </test-auth-nr/> .
+    http:requestURI </test-auth-bc/> .
+
 
 :teardown_verify_its_gone a http:RequestMessage ;
     http:method "GET" ;
-    http:requestURI </test-auth-nr/> .
+    http:requestURI </test-auth-rs/> .

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_nonrdfsource.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_nonrdfsource.ttl
@@ -4,19 +4,21 @@
 @prefix http: <http://www.w3.org/2007/ont/http#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
-@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_bc.ttl#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_nonrdfsource.ttl#> .
 
 :test_list a test:FixtureTable ;
-    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on an LDP-BC controlled by the ACL system with unspecified interaction model."@en ;
+    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on a non-RDF source controlled by the ACL system."@en ;
     test:fixtures (
         :setup_init
-        :test_bob_r_bc
+        :test_bob_r_nr
         :setup_append
-        :test_bob_a_bc
+        :test_bob_a_nr
         :setup_read_append
-        :test_bob_ar_bc
+        :test_bob_ar_nr
         :setup_read_write
-        :test_bob_rw_bc
+        :test_bob_rw_nr
+        :setup_read_write_container
+        :test_bob_delete_nr
         :teardown
     ) .
 
@@ -32,86 +34,76 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_bc_req ;
+                test:request :setup_alice_share_bob_nr_req ;
                 test:response_assertion :created_ok_res
             ]
             [
-                test:request :setup_alice_share_bob_r_bc_acl_req ;
+                test:request :setup_alice_share_bob_r_nr_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_bc_req a http:RequestMessage ;
-    rdfs:comment "Set up RDF BC resource for Bob.";
-    http:method "POST" ;
-    http:requestURI </> ;
-    httph:slug "test-auth-bc" ;
-    httph:content_type "text/turtle";
-    httph:link """<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"""";
-    http:content """@prefix dc: <http://purl.org/dc/terms/>.
-@prefix ldp: <http://www.w3.org/ns/ldp#>.
-<> a ldp:BasicContainer ;
-   dc:title "Initial container for Bobs stuff"@en .""" .
-
-
-
-:setup_alice_share_bob_r_bc_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Basic Container for Bob to read.";
+:setup_alice_share_bob_nr_req a http:RequestMessage ;
+    rdfs:comment "Set up Non-RDF resource for Bob.";
     http:method "PUT" ;
-    http:requestURI </test-auth-bc/.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> ;
+    httph:content_type "text/plain" ;
+    http:content "protected contents, that Alice gives Bob Read to." .
+
+
+:setup_alice_share_bob_r_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read.";
+    http:method "PUT" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read.
 """ .
 
-:test_bob_r_bc a test:AutomatedTest ;
-    test:purpose "Check that Bob can only read Basic Container when he is authorized read only."@en ;
+:test_bob_r_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can only read Non-RDF resource when he is authorized read only."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_bc_read_req ;
+                test:request :test_bob_nr_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_bc_head_req ;
+                test:request :test_bob_nr_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_bc_options_req ;
+                test:request :test_bob_nr_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_bc_write_req ;
+                test:request :test_bob_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_patch_req ;
+                test:request :test_bob_nr_patch_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_patch_req ;
+                test:request :test_bob_nr_append_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_append_req ;
+                test:request :test_bob_nr_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_delete_req ;
-                test:response_assertion :forbidden_res ;
-            ]
-            [
-                test:request :test_bob_bc_other_req ;
+                test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -126,70 +118,65 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_a_bc_acl_req ;
+                test:request :setup_alice_share_bob_a_nr_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_a_bc_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Basic Container for Bob to append.";
+:setup_alice_share_bob_a_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to append.";
     http:method "PUT" ;
-    http:requestURI </test-auth-bc/.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Append.
 """ .
 
 
-:test_bob_a_bc a test:AutomatedTest ;
-    test:purpose "Check that Bob can only append to Basic Container when he is authorized append only."@en ;
+:test_bob_a_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can only append to Non-RDF resource when he is authorized append only."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_bc_read_req ;
+                test:request :test_bob_nr_read_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_head_req ;
+                test:request :test_bob_nr_head_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_options_req ;
+                test:request :test_bob_nr_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_bc_write_req ;
-                test:response_assertion :forbidden_res ;
-            ]
-             # TODO: NSS returns 500 when patching container
-            # [
-             #     test:request :test_bob_bc_patch_req ;
-             #     test:response_assertion :ok_res ;
-             # ]
-            [
-                test:request :test_bob_bc_patch_with_delete_req ;
+                test:request :test_bob_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_append_req ;
-                test:response_assertion :created_ok_res ;
+                test:request :test_bob_nr_patch_req ;
+                test:response_assertion :unsupported_media_type_res ;
             ]
             [
-                test:request :test_bob_bc_delete_req ;
+                test:request :test_bob_nr_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_nr_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_other_req ;
+                test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -204,70 +191,65 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_ar_bc_acl_req ;
+                test:request :setup_alice_share_bob_ar_nr_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_ar_bc_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Basic Container for Bob to read and append.";
+:setup_alice_share_bob_ar_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and append.";
     http:method "PUT" ;
-    http:requestURI </test-auth-bc/.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Append.
 """ .
 
 
-:test_bob_ar_bc a test:AutomatedTest ;
-    test:purpose "Check that Bob can read and append to Basic Container when he is authorized read-append."@en ;
+:test_bob_ar_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and append to Non-RDF resource when he is authorized read-append."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_bc_read_req ;
+                test:request :test_bob_nr_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_bc_head_req ;
+                test:request :test_bob_nr_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_bc_options_req ;
+                test:request :test_bob_nr_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_bc_write_req ;
-                test:response_assertion :forbidden_res ;
-            ]
-            # TODO: NSS returns 500 when patching container
-             # [
-             #     test:request :test_bob_bc_patch_req ;
-             #     test:response_assertion :ok_res ;
-             # ]
-            [
-                test:request :test_bob_bc_patch_with_delete_req ;
+                test:request :test_bob_nr_write_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_append_req ;
-                test:response_assertion :created_ok ;
+                test:request :test_bob_nr_patch_req ;
+                test:response_assertion :unsupported_media_type_res ;
             ]
             [
-                test:request :test_bob_bc_delete_req ;
+                test:request :test_bob_nr_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_nr_delete_req ;
                 test:response_assertion :forbidden_res ;
             ]
             [
-                test:request :test_bob_bc_other_req ;
+                test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
         )
@@ -280,70 +262,65 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_rw_bc_acl_req ;
+                test:request :setup_alice_share_bob_rw_nr_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:setup_alice_share_bob_rw_bc_acl_req a http:RequestMessage ;
-    rdfs:comment "Set up ACL for Basic Container for Bob to read and write.";
+:setup_alice_share_bob_rw_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
     http:method "PUT" ;
-    http:requestURI </test-auth-bc/.acl> ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> ;
     httph:content_type "text/turtle" ;
     http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
 <#owner> a acl:Authorization;
   acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write, acl:Control.
 <#bob> a acl:Authorization;
   acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
-  acl:accessTo </test-auth-bc/>;
+  acl:accessTo </test-auth-nr/alice_share_bob.txt>;
   acl:mode acl:Read, acl:Write.
 """ .
 
 
-:test_bob_rw_bc a test:AutomatedTest ;
-    test:purpose "Check that Bob can read and write to Basic Container when he is authorized read-write."@en ;
+:test_bob_rw_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can read and write to Non-RDF resource when he is authorized read-write."@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
         test:steps (
             [
-                test:request :test_bob_bc_read_req ;
+                test:request :test_bob_nr_read_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_bc_head_req ;
+                test:request :test_bob_nr_head_req ;
                 test:response_assertion :ok_res ;
             ]
             [
-                test:request :test_bob_bc_options_req ;
+                test:request :test_bob_nr_options_req ;
                 test:response_assertion :no_content_res ;
             ]
             [
-                test:request :test_bob_bc_write_req ;
+                test:request :test_bob_nr_write_req ;
                 test:response_assertion :created_res ; # TODO: Really?
             ]
-            # TODO: NSS returns 500 when patching container
-             # [
-             #     test:request :test_bob_bc_patch_req ;
-             #     test:response_assertion :ok_res ; # TODO: Check deletes
-             # ]
-             # [
-             #     test:request :test_bob_bc_patch_with_delete_req ;
-             #     test:response_assertion :ok_res ;
-             # ]
             [
-                test:request :test_bob_bc_append_req ;
-                test:response_assertion :created_ok ;
+                test:request :test_bob_nr_patch_req ;
+                test:response_assertion :unsupported_media_type_res ;
             ]
             [
-                test:request :test_bob_bc_other_req ;
+                test:request :test_bob_nr_append_req ;
+                test:response_assertion :not_found_res ; # TODO: Doesn't support hierarchy, should be :no_content_res ;
+            ]
+            [
+                test:request :test_bob_nr_other_req ;
                 test:response_assertion :invalid_req_res ;
             ]
             [
-                test:request :test_bob_bc_delete_req ;
+                test:request :test_bob_nr_delete_req ;
                 test:response_assertion :forbidden_res ; # Because Bob doesn't have write permission on the container
             ]
         )
@@ -357,61 +334,78 @@
         <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/ALICE_ID_GOOD> ;
         test:steps (
             [
-                test:request :setup_alice_share_bob_rw_container_bc_acl_req ;
+                test:request :setup_alice_share_bob_rw_container_nr_acl_req ;
                 test:response_assertion :created_ok_res
             ]
         )
     ] .
 
-:test_bob_bc_read_req a http:RequestMessage ;
-    http:method "GET" ;
-    http:requestURI </test-auth-bc/> .
-
-:test_bob_bc_head_req a http:RequestMessage ;
-    http:method "HEAD" ;
-    http:requestURI </test-auth-bc/> .
-
-:test_bob_bc_options_req a http:RequestMessage ;
-    http:method "OPTIONS" ;
-    http:requestURI </test-auth-bc/> .
-
-:test_bob_bc_write_req a http:RequestMessage ;
+:setup_alice_share_bob_rw_container_nr_acl_req a http:RequestMessage ;
+    rdfs:comment "Set up ACL for Non-RDF resource for Bob to read and write.";
     http:method "PUT" ;
-    http:content """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-<> rdfs:comment "Bob replaced it." .
-    """ ;
+    http:requestURI </test-auth-nr/.acl> ;
     httph:content_type "text/turtle" ;
-    http:requestURI </test-auth-bc/> .
+    http:content """@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+<#owner> a acl:Authorization;
+  acl:agent <https://alice.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-nr/>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+<#bob> a acl:Authorization;
+  acl:agent <https://bobwebid.idp.test.solidproject.org/profile/card#me>;
+  acl:accessTo </test-auth-nr/>;
+  acl:mode acl:Read, acl:Write.
+""" .
 
-:test_bob_bc_patch_req a http:RequestMessage ;
+:test_bob_delete_nr a test:AutomatedTest ;
+    test:purpose "Check that Bob can delete Non-RDF resource when he is authorized read-write on the container."@en ;
+    test:test_script <http://example.org/httplist#http_req_res_list> ;
+    test:params [
+        <http://example.org/httplist/param#bearer> <https://idp.test.solidproject.org/tokens/BOB_ID_GOOD> ;
+        test:steps (
+            [
+                test:request :test_bob_nr_delete_req ;
+                test:response_assertion :deleted_ok_res ;
+            ]
+        )
+    ] .
+
+:test_bob_nr_read_req a http:RequestMessage ;
+    http:method "GET" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+
+:test_bob_nr_head_req a http:RequestMessage ;
+    http:method "HEAD" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+
+:test_bob_nr_options_req a http:RequestMessage ;
+    http:method "OPTIONS" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+
+:test_bob_nr_write_req a http:RequestMessage ;
+    http:method "PUT" ;
+    http:content "Bob's replacement"@en ;
+    httph:content_type "text/plain" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+
+:test_bob_nr_patch_req a http:RequestMessage ;
     http:method "PATCH" ;
-    http:content "INSERT DATA { <> a <http://example.org/Foo> . }" ;
-    httph:content_type "application/sparql-update" ;
-    http:requestURI </test-auth-bc/> .
+    http:content "+Bob's patch"@en ;
+    httph:content_type "text/plain" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
-:test_bob_bc_patch_with_delete_req a http:RequestMessage ;
-    http:method "PATCH" ;
-    http:content """DELETE { ?s a ?o . } INSERT { <> a <http://example.org/Bar> . }
-WHERE  { ?s a ?o . }""" ;
-    httph:content_type "application/sparql-update" ;
-    http:requestURI </test-auth-bc/> .
-
-:test_bob_bc_append_req a http:RequestMessage ;
+:test_bob_nr_append_req a http:RequestMessage ;
     http:method "POST" ;
-    http:content """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-<> rdfs:comment "Bob added this."
-    """ ;
-    httph:slug "bobsdata" ;
-    httph:content_type "text/turtle" ;
-    http:requestURI </test-auth-bc/> .
+    http:content "Bob's addition"@en ;
+    httph:content_type "text/plain" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
-:test_bob_bc_delete_req a http:RequestMessage ;
+:test_bob_nr_delete_req a http:RequestMessage ;
     http:method "DELETE" ;
-    http:requestURI </test-auth-bc/> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
-:test_bob_bc_other_req a http:RequestMessage ;
+:test_bob_nr_other_req a http:RequestMessage ;
     http:method "DAHU" ;
-    http:requestURI </test-auth-bc/> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
 
 
 :created_ok_res a http:ResponseMessage ;
@@ -450,8 +444,8 @@ WHERE  { ?s a ?o . }""" ;
                 test:response_assertion :deleted_ok_res
             ]
             [
-                test:request :teardown_alice_share_bob_req ;
-                test:response_assertion :not_found_res
+                test:request :teardown_test_dir ;
+                test:response_assertion :deleted_ok_res
             ]
             [
                 test:request :teardown_verify_its_gone ;
@@ -461,16 +455,20 @@ WHERE  { ?s a ?o . }""" ;
         )
     ] .
 
+:teardown_alice_share_bob_req a http:RequestMessage ;
+    http:method "DELETE" ;
+    http:requestURI </test-auth-nr/alice_share_bob.txt> .
+
 :teardown_alice_share_bob_acl_req a http:RequestMessage ;
     rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
     http:method "DELETE" ;
-    http:requestURI </test-auth-bc/.acl> .
+    http:requestURI </test-auth-nr/alice_share_bob.txt.acl> .
 
-:teardown_alice_share_bob_req a http:RequestMessage ;
+:teardown_test_dir a http:RequestMessage ;
+    rdfs:comment "Open issue: https://github.com/solid/specification/issues/58"@en ; # TODO, we should have a predicate for this... :-)
     http:method "DELETE" ;
-    http:requestURI </test-auth-bc/> .
-
+    http:requestURI </test-auth-nr/> .
 
 :teardown_verify_its_gone a http:RequestMessage ;
     http:method "GET" ;
-    http:requestURI </test-auth-rs/> .
+    http:requestURI </test-auth-nr/> .

--- a/testers/rdf-fixtures/fixture-tables/operations_protected_rdfsource.ttl
+++ b/testers/rdf-fixtures/fixture-tables/operations_protected_rdfsource.ttl
@@ -4,10 +4,10 @@
 @prefix http: <http://www.w3.org/2007/ont/http#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
-@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_ldp_rs.ttl#> .
+@prefix :     <https://github.com/solid/test-suite/blob/master/testers/rdf-fixtures/fixture-tables/operations_protected_rdfsource.ttl#> .
 
 :test_list a test:FixtureTable ;
-    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on an LDP-RS controlled by the ACL system."@en ;
+    rdfs:comment "These tests exist to provide a high-level overview of allowed manipulations on an RDF Source controlled by the ACL system."@en ;
     test:fixtures (
         :setup_init
         :test_bob_r_rs

--- a/testers/rdf-fixtures/run-scripts/auth-focused.t
+++ b/testers/rdf-fixtures/run-scripts/auth-focused.t
@@ -49,11 +49,11 @@ my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 use Test::FITesque::RDF;
 
 my @files = qw(
-					 authentication.ttl
-					 http-put-check-acl.ttl
-					 operations_protected_ldp_rs.ttl
-					 operations_protected_ldp_nr.ttl
-					 operations_protected_ldp_bc.ttl
+  authentication.ttl
+  http-put-check-acl.ttl
+  operations_protected_cont.ttl
+  operations_protected_nonrdfsource.ttl
+  operations_protected_rdfsource.ttl
 				 );
 
 

--- a/testers/rdf-fixtures/run-scripts/auth-focused.t
+++ b/testers/rdf-fixtures/run-scripts/auth-focused.t
@@ -4,7 +4,7 @@
 
 =head1 PURPOSE
 
-Testing HTTP interface functionality of a Solid server
+Testing HTTP interface authentication and authorization functionality with of a Solid server
 
 =head1 ENVIRONMENT
 
@@ -22,7 +22,7 @@ Kjetil Kjernsmo E<lt>kjetilk@cpan.orgE<gt>.
 
 =head1 COPYRIGHT AND LICENCE
 
-This software is Copyright (c) 2019 by Inrupt Inc.
+This software is Copyright (c) 2020 by Inrupt Inc.
 
 This is free software, licensed under:
 
@@ -48,7 +48,13 @@ my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;
 
-my @files = ('authentication.ttl','operations_protected_ldp_nr.ttl','operations_protected_ldp_rs.ttl');
+my @files = qw(
+					 authentication.ttl
+					 http-put-check-acl.ttl
+					 operations_protected_ldp_rs.ttl
+					 operations_protected_ldp_nr.ttl
+					 operations_protected_ldp_bc.ttl
+				 );
 
 
 BAIL_OUT("Set SOLID_REMOTE_BASE to the URL of the base of the server you are testing") unless $ENV{SOLID_REMOTE_BASE};

--- a/testers/rdf-fixtures/run-scripts/http-method-focused.t
+++ b/testers/rdf-fixtures/run-scripts/http-method-focused.t
@@ -22,7 +22,7 @@ Kjetil Kjernsmo E<lt>kjetilk@cpan.orgE<gt>.
 
 =head1 COPYRIGHT AND LICENCE
 
-This software is Copyright (c) 2019 by Inrupt Inc.
+This software is Copyright (c) 2020 by Inrupt Inc.
 
 This is free software, licensed under:
 
@@ -43,13 +43,27 @@ BEGIN {
   $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = 'IO::Socket::SSL';
 }
 
+
 my $path = $ENV{SOLID_FIXTURE_PATH} || '/opt/fixture-tables/';
 
 use Test::FITesque::RDF;
 
+my @files = qw(
+					 operations_post_with_slug.ttl
+					 operations_put_resource.ttl
+					 operations_put_container.ttl
+				 );
+
+
 BAIL_OUT("Set SOLID_REMOTE_BASE to the URL of the base of the server you are testing") unless $ENV{SOLID_REMOTE_BASE};
 
-my $suite = Test::FITesque::RDF->new(source => $path . 'http-put-check-acl.ttl', base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
+
+my $suite = Test::FITesque::Suite->new;
+
+foreach my $file (@files) {
+  note("Reading tests from $path$file");
+  $suite->add(Test::FITesque::RDF->new(source => $path . $file, base_uri => $ENV{SOLID_REMOTE_BASE})->suite);
+}
 
 $suite->run_tests;
 


### PR DESCRIPTION
This consolidates the run scripts, so that they iterate over the fixture tables. I have now two rough categories, though it shouldn't matter much how they are grouped.

I have also toned down the LDP compliance somewhat.