### PR TITLE
Lock version of CSS results

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ their continuous integration:
 * [Node Solid Server](https://github.com/solid/node-solid-server/blob/master/test/surface/run-solid-test-suite.sh) (webid + crud + wac)
 * [PHP Solid Server](https://github.com/pdsinterop/php-solid-server/blob/master/run-solid-test-suite.sh) (only webid + crud, so far)
 * [Solid-Nextcloud](https://github.com/pdsinterop/php-solid-server/blob/master/run-solid-test-suite.sh) (only webid + crud, so far)
-* [Community Solid Server](https://github.com/solid/community-server/blob/master/test/system/run-solid-test-suite.sh) (only crud, so far)
 * Inrupt ESS (coming soon!)
 * TrinPod (coming soon!)
 
@@ -32,7 +31,7 @@ The following servers run the Solid CRUD tests:
 * `*************************************************************` [PHP Solid Server](https://github.com/pdsinterop/php-solid-server): 61/61
 * `*************************************************************` [Nextcloud Server](https://github.com/nextcloud/server) (with [Solid-Nextcloud](https://github.com/pdsinterop/solid-nextcloud) enabled): 61/61
 * `*********************************************` [Node Solid Server](https://github.com/solid/node-solid-server/pull/1492#issuecomment-726668190): 45/61
-* `********` [Community Solid Server](https://github.com/solid/community-server/pull/278#issuecomment-724651937): 8/61
+* `********` [Community Solid Server v0.2.0](https://github.com/solid/community-server/pull/278#issuecomment-724651937): 8/61
 
 ## Web Access Control Tests (version 2.1)
 


### PR DESCRIPTION
Hi all,

Really appreciate your work on the test suite. Unfortunately, tests are currently not running properly on the Community Solid Server, so we saw ourselves forced to remove them for now (https://github.com/solid/community-server/commit/3bd82271b4cb1bebba5ac7431d00bad540a25a88).

Whereas CSS v0.2.0 was passing some of the tests, the same tests are not running anymore against the latest version (v0.3.0), despite the required functionality confirmed present and working. Furthermore, the current version of solid-crud-tests has a mechanism that is too brittle for our setup. We would be okay with running an `npx solid-crud-tests` or similar, but it currently requires a script on our side with multiple steps that change between test versions, and we are not able to obtain correct results in a straightforward and sustainable way.

Hence, this PR:
- locks the version of the CSS result to the version of the server they have been obtained with
- removes CSS from the list of servers with the test suite in CI